### PR TITLE
Fix arithmetic overflow panic on malformed leaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Arithmetic overflow panic on malformed leaders** ([#32](https://github.com/dchud/mrrc/issues/32)): `MarcReader`, `AuthorityReader`, and `HoldingsReader` now return `Err(MarcError::InvalidLeader)` instead of panicking when `record_length` or `data_base_address` in the leader is less than 24. New `Leader::validate_for_reading()` method performs the check in all three binary readers.
+
 ### Documentation
 
 - Updated migration guide (`docs/guides/migration-from-pymarc.md`) to recommend path-based `MARCReader` input instead of Python file objects, with comments explaining GIL release and multi-thread parallelism benefits.

--- a/src/authority_reader.rs
+++ b/src/authority_reader.rs
@@ -103,6 +103,7 @@ impl<R: Read> AuthorityMarcReader<R> {
         }
 
         let leader = Leader::from_bytes(&leader_bytes)?;
+        leader.validate_for_reading()?;
 
         // Verify this is an authority record (Type Z)
         if leader.record_type != 'z' {

--- a/src/holdings_reader.rs
+++ b/src/holdings_reader.rs
@@ -101,6 +101,7 @@ impl<R: Read> HoldingsMarcReader<R> {
         }
 
         let leader = Leader::from_bytes(&leader_bytes)?;
+        leader.validate_for_reading()?;
 
         // Verify this is a holdings record (Type x/y/v/u)
         if !matches!(leader.record_type, 'x' | 'y' | 'v' | 'u') {


### PR DESCRIPTION
## Summary

- Add `Leader::validate_for_reading()` method that checks `record_length` and `data_base_address` are >= 24 before binary readers perform `- 24` subtraction
- Call validation in all three binary readers (`MarcReader`, `AuthorityReader`, `HoldingsReader`)
- Return `Err(MarcError::InvalidLeader(...))` instead of panicking on underflow

Closes #32

## Test plan

- [x] New unit tests in `leader.rs` for `validate_for_reading()` with small record_length and base_address
- [x] New integration tests in `reader.rs` exercising `MarcReader::read_record()` with malformed leaders
- [x] All existing tests pass (465 lib + 485 Python)
- [x] Full `.cargo/check.sh` passes (fmt, clippy, doc, audit, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)