### PR TITLE
Use path strings instead of Python file I/O in examples

### DIFF
--- a/examples/concurrent_reading.py
+++ b/examples/concurrent_reading.py
@@ -50,18 +50,18 @@ def process_file(filename: str) -> dict:
     errors = 0
     
     try:
-        with open(filename, 'rb') as f:
-            # Create a NEW reader for this thread
-            reader = MARCReader(f)
-            
-            for record in reader:
-                record_count += 1
-                
-                # Extract some data to demonstrate processing
-                if record.title():
-                    title_count += 1
-                if record.author():
-                    author_count += 1
+        # Create a NEW reader for this thread — pass path string
+        # so mrrc uses Rust I/O with GIL released
+        reader = MARCReader(filename)
+
+        for record in reader:
+            record_count += 1
+
+            # Extract some data to demonstrate processing
+            if record.title():
+                title_count += 1
+            if record.author():
+                author_count += 1
                     
     except Exception as e:
         errors = 1

--- a/examples/concurrent_reading_producer_consumer.py
+++ b/examples/concurrent_reading_producer_consumer.py
@@ -88,14 +88,13 @@ def main():
     title_count = 0
     author_count = 0
     
-    with open(marc_file, 'rb') as f:
-        reader = MARCReader(f)
-        for record in reader:
-            record_count += 1
-            if record.title():
-                title_count += 1
-            if record.author():
-                author_count += 1
+    reader = MARCReader(str(marc_file))
+    for record in reader:
+        record_count += 1
+        if record.title():
+            title_count += 1
+        if record.author():
+            author_count += 1
     
     seq_time = time.time() - start
     print(f"Time:           {seq_time:.3f}s")

--- a/examples/concurrent_writing.py
+++ b/examples/concurrent_writing.py
@@ -50,17 +50,17 @@ def copy_records(input_file: str, output_file: str) -> dict:
     errors = 0
     
     try:
-        with open(input_file, 'rb') as infile:
-            with open(output_file, 'wb') as outfile:
-                # Create separate reader and writer for this thread
-                reader = MARCReader(infile)
-                writer = MARCWriter(outfile)
-                
-                for record in reader:
-                    records_read += 1
-                    writer.write_record(record)
-                    records_written += 1
-                    
+        # Pass path strings so mrrc uses Rust I/O with GIL released
+        reader = MARCReader(input_file)
+        writer = MARCWriter(output_file)
+
+        for record in reader:
+            records_read += 1
+            writer.write_record(record)
+            records_written += 1
+
+        writer.close()
+
         # Verify file was created
         if not os.path.exists(output_file):
             errors = 1

--- a/examples/creating_records.py
+++ b/examples/creating_records.py
@@ -296,23 +296,24 @@ def writing_records():
     import tempfile
     import os
     
-    with tempfile.NamedTemporaryFile(mode='wb', suffix='.mrc', delete=False) as f:
-        temp_file = f.name
-        writer = MARCWriter(f)
-        for record in records:
-            writer.write_record(record)
-    
+    temp_file = tempfile.mktemp(suffix='.mrc')
+
+    # Pass path string so mrrc uses Rust I/O with GIL released
+    writer = MARCWriter(temp_file)
+    for record in records:
+        writer.write_record(record)
+    writer.close()
+
     try:
         # Read back and verify
         print(f"Wrote {len(records)} records to {temp_file}")
-        
-        with open(temp_file, 'rb') as f:
-            reader = MARCReader(f)
-            read_count = 0
-            print("\nRecords read back:")
-            for record in reader:
-                print(f"  {read_count + 1}. {record.title()}")
-                read_count += 1
+
+        reader = MARCReader(temp_file)
+        read_count = 0
+        print("\nRecords read back:")
+        for record in reader:
+            print(f"  {read_count + 1}. {record.title()}")
+            read_count += 1
         
         print(f"\nVerification: {read_count}/{len(records)} records successfully round-tripped")
         
@@ -435,10 +436,10 @@ def main():
    ])
    record.add_control_field('001', 'my-control-number')
 
-   # Write
-   with open('output.mrc', 'wb') as f:
-       writer = MARCWriter(f)
-       writer.write_record(record)
+   # Write — pass path string for Rust I/O (releases GIL)
+   writer = MARCWriter('output.mrc')
+   writer.write_record(record)
+   writer.close()
    ```
 
 5. PYMARC COMPATIBILITY:

--- a/examples/reading_and_querying.py
+++ b/examples/reading_and_querying.py
@@ -34,9 +34,8 @@ def create_sample_record_from_binary():
     if test_dir.exists():
         marc_files = list(test_dir.glob('*.mrc'))
         if marc_files:
-            with open(marc_files[0], 'rb') as f:
-                reader = MARCReader(f)
-                return reader.read_record()
+            reader = MARCReader(str(marc_files[0]))
+            return reader.read_record()
     
     # If no test file available, return None
     return None

--- a/mrrc/_mrrc.pyi
+++ b/mrrc/_mrrc.pyi
@@ -326,21 +326,19 @@ class MARCReader:
         GIL is released during record parsing (Phase 2).
 
     Examples:
-        Simple sequential reading::
+        Simple sequential reading (path string uses Rust I/O, releases GIL)::
 
-            with open('records.mrc', 'rb') as f:
-                reader = mrrc.MARCReader(f)
-                for record in reader:
-                    print(record.title())
+            reader = mrrc.MARCReader('records.mrc')
+            for record in reader:
+                print(record.title())
 
         Parallel processing with ThreadPoolExecutor::
 
             from concurrent.futures import ThreadPoolExecutor
 
             def process_file(filename):
-                with open(filename, 'rb') as f:
-                    reader = mrrc.MARCReader(f)  # New reader per thread
-                    return sum(1 for _ in reader)
+                reader = mrrc.MARCReader(filename)  # New reader per thread
+                return sum(1 for _ in reader)
 
             with ThreadPoolExecutor(max_workers=4) as executor:
                 futures = [executor.submit(process_file, f) for f in file_list]


### PR DESCRIPTION
## Summary
- Replace `open(..., 'rb')` / `open(..., 'wb')` with path strings passed directly to `MARCReader`/`MARCWriter` in all Python examples
- Path strings route to Rust I/O backend which releases the GIL, vs Python file objects which hold it
- Updated docstring examples in `mrrc/_mrrc.pyi` to match

Closes #53 (bead: mrrc-11bj)

## Test plan
- [x] `.cargo/check.sh` passes (all 485 Python tests, 465 Rust tests, doc tests, lint)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)