### PR TITLE
Migrate bd references to br in docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,47 +1,55 @@
 # GitHub Copilot Instructions
 
-## Issue Tracking with bd
+## Issue Tracking with br (beads_rust)
 
-This project uses **bd (beads)** for issue tracking - a Git-backed tracker designed for AI-supervised coding workflows.
+This project uses **br (beads_rust)** for issue tracking - a Git-backed tracker designed for AI-supervised coding workflows.
+
+**Note:** `br` is non-invasive and never executes git commands. After `br sync --flush-only`, you must manually run `git add .beads/ && git commit`.
 
 **Key Features:**
 - Dependency-aware issue tracking
 - Auto-sync with Git via JSONL
 - AI-optimized CLI with JSON output
-- Built-in daemon for background operations
 - MCP server integration for Claude and other AI assistants
 
-**CRITICAL**: Use bd for ALL task tracking. Do NOT create markdown TODO lists.
+**CRITICAL**: Use br for ALL task tracking. Do NOT create markdown TODO lists.
 
 ### Essential Commands
 
 ```bash
 # Find work
-bd ready --json                    # Unblocked issues
-bd stale --days 30 --json          # Forgotten issues
+br ready --json                    # Unblocked issues
+br stale --days 30 --json          # Forgotten issues
 
 # Create and manage
-bd create "Title" -t bug|feature|task -p 0-4 --json
-bd create "Subtask" --parent <epic-id> --json  # Hierarchical subtask
-bd update <id> --status in_progress --json
-bd close <id> --reason "Done" --json
+br create "Title" -t bug|feature|task -p 0-4 --json
+br create "Subtask" --parent <epic-id> --json  # Hierarchical subtask
+br update <id> --status in_progress --json
+br close <id> --reason "Done" --json
 
 # Search
-bd list --status open --priority 1 --json
-bd show <id> --json
+br list --status open --priority 1 --json
+br show <id> --json
 
 # Sync (CRITICAL at end of session!)
-bd sync  # Force immediate export/commit/push
+br sync --flush-only
+git add .beads/
+git commit -m "sync beads"
 ```
 
 ### Workflow
 
-1. **Check ready work**: `bd ready --json`
-2. **Claim task**: `bd update <id> --status in_progress`
+1. **Check ready work**: `br ready --json`
+2. **Claim task**: `br update <id> --status in_progress`
 3. **Work on it**: Implement, test, document
-4. **Discover new work?** `bd create "Found bug" -p 1 --deps discovered-from:<parent-id> --json`
-5. **Complete**: `bd close <id> --reason "Done" --json`
-6. **Sync**: `bd sync` (flushes changes to git immediately)
+4. **Discover new work?** `br create "Found bug" -p 1 --deps discovered-from:<parent-id> --json`
+5. **Complete**: `br close <id> --reason "Done" --json`
+6. Sync and commit:
+   ```bash
+   br sync --flush-only
+   git add .beads/
+   git commit -m "sync beads"
+   ```
 
 ### Priorities
 
@@ -54,8 +62,7 @@ bd sync  # Force immediate export/commit/push
 ### Git Workflow
 
 - Always commit `.beads/issues.jsonl` with code changes
-- Run `bd sync` at end of work sessions
-- Install git hooks: `bd hooks install` (ensures DB ↔ JSONL consistency)
+- Run `br sync --flush-only` at end of work sessions, then `git add .beads/ && git commit`
 
 ### MCP Server (Recommended)
 
@@ -65,14 +72,14 @@ For MCP-compatible clients (Claude Desktop, etc.), install the beads MCP server:
 
 ## CLI Help
 
-Run `bd <command> --help` to see all available flags for any command.
-For example: `bd create --help` shows `--parent`, `--deps`, `--assignee`, etc.
+Run `br <command> --help` to see all available flags for any command.
+For example: `br create --help` shows `--parent`, `--deps`, `--assignee`, etc.
 
 ## Important Rules
 
-- ✅ Use bd for ALL task tracking
+- ✅ Use br for ALL task tracking
 - ✅ Always use `--json` flag for programmatic use
-- ✅ Run `bd sync` at end of sessions
-- ✅ Run `bd <cmd> --help` to discover available flags
+- ✅ Run `br sync --flush-only` at end of sessions, then git add/commit
+- ✅ Run `br <cmd> --help` to discover available flags
 - ❌ Do NOT create markdown TODO lists
 - ❌ Do NOT commit `.beads/beads.db` (JSONL only)

--- a/docs/contributing/release-procedure.md
+++ b/docs/contributing/release-procedure.md
@@ -994,7 +994,7 @@ If you have identified planned work items for the next release, create beads iss
 
 Example workflow:
 1. After release, review roadmap and open issues
-2. Create new issues for planned work: `bd create "Feature: ..." -p 2`
+2. Create new issues for planned work: `br create "Feature: ..." -p 2`
 3. Link major items in README roadmap or docs/RELEASES.md (but NOT in CHANGELOG [Unreleased])
 4. The [Unreleased] section fills up organically as work is completed during development
 


### PR DESCRIPTION
## Summary
- Migrate `.github/copilot-instructions.md`: full bd→br migration (all commands, sync workflow with explicit git steps, remove daemon/hook references, add non-invasive note)
- Migrate `docs/contributing/release-procedure.md`: `bd create` → `br create`
- Remove stale bd git hooks (pre-commit, prepare-commit-msg, pre-push, post-checkout, post-merge) that called `bd hook` which doesn't exist in br

## Test plan
- [x] `.cargo/check.sh --quick` passes
- [x] Verified 0 `bd` references remain in migrated files
- [x] Verified `br sync --flush-only` appears in sync sections
- [x] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)