### PR TITLE
Fix check.sh --quick to skip Python tests that need maturin build

### DIFF
--- a/.cargo/check.sh
+++ b/.cargo/check.sh
@@ -39,6 +39,18 @@ echo ""
 echo "=== Clippy check (mrrc-python) ==="
 cargo clippy --package mrrc-python --all-targets -- -D warnings
 
+echo ""
+echo "=== Python lint (ruff) ==="
+uv run ruff check mrrc/ tests/python/
+
+echo ""
+echo "=== Rust library + integration tests ==="
+cargo test --lib --tests --package mrrc -q
+
+echo ""
+echo "=== Rust doc tests ==="
+cargo test --doc --package mrrc -q
+
 if [ "$QUICK" = false ]; then
     echo ""
     echo "=== Documentation check ==="
@@ -51,23 +63,11 @@ if [ "$QUICK" = false ]; then
     echo ""
     echo "=== Maturin Python extension build ==="
     uv run maturin develop
+
+    echo ""
+    echo "=== Python tests (core functionality, excludes benchmarks) ==="
+    uv run python -m pytest tests/python/ -m "not benchmark" -q
 fi
-
-echo ""
-echo "=== Rust library + integration tests ==="
-cargo test --lib --tests --package mrrc -q
-
-echo ""
-echo "=== Rust doc tests ==="
-cargo test --doc --package mrrc -q
-
-echo ""
-echo "=== Python tests (core functionality, excludes benchmarks) ==="
-uv run python -m pytest tests/python/ -m "not benchmark" -q
-
-echo ""
-echo "=== Python lint (ruff) ==="
-uv run ruff check mrrc/ tests/python/
 
 # ASAN memory safety checks (optional, nightly feature)
 if [ "$MEMORY_CHECKS" = true ]; then


### PR DESCRIPTION
## Summary
- `--quick` previously skipped the maturin build but still ran Python tests, so after Rust changes the tests ran against a stale extension
- Now `--quick` runs: rustfmt, clippy (both crates), ruff, Rust tests, doc tests (~10s)
- Full mode adds: doc check, audit, maturin build, Python tests (~16s)

Closes bd-3peu

## Test plan
- [x] `check.sh --quick` passes (~10s)
- [x] `check.sh` (full) passes (~16s)
- [x] Pre-commit hook (quick) and pre-push hook (full) both verified
- [x] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)