### PR TITLE
docs: rewrite iso2709 + reader comments in declarative terms

### DIFF
--- a/src/authority_reader.rs
+++ b/src/authority_reader.rs
@@ -112,15 +112,13 @@ impl<R: Read> AuthorityMarcReader<R> {
         let base_address = leader.data_base_address as usize;
         let directory_size = base_address - 24;
 
-        // Read record data; in non-Strict modes a short read returns
-        // `(buffer, true)` and the recovery branch below handles it.
+        // Read record data. In non-Strict modes a short read returns
+        // `(buffer, true)`; salvage from a partial buffer is not implemented,
+        // so the recovery dispatch below is unreachable in practice (the read
+        // primitive returns a buffer of full length even on a short read).
         let (record_data, _was_truncated) =
             iso2709::read_record_data(&mut self.reader, record_length, self.recovery_mode)?;
 
-        // Handle truncation in recovery mode. The comparison is preserved
-        // verbatim from the pre-refactor reader: because the buffer is
-        // allocated at full length it is effectively dead today, and
-        // intentionally left so by PR1 to avoid any semantic change.
         if record_data.len() < (record_length - 24) && self.recovery_mode != RecoveryMode::Strict {
             // For now, treat truncated authority records as a strict error
             // In the future, we could implement recovery logic

--- a/src/holdings_reader.rs
+++ b/src/holdings_reader.rs
@@ -110,15 +110,13 @@ impl<R: Read> HoldingsMarcReader<R> {
         let base_address = leader.data_base_address as usize;
         let directory_size = base_address - 24;
 
-        // Read record data; in non-Strict modes a short read returns
-        // `(buffer, true)` and the recovery branch below handles it.
+        // Read record data. In non-Strict modes a short read returns
+        // `(buffer, true)`; salvage from a partial buffer is not implemented,
+        // so the recovery dispatch below is unreachable in practice (the read
+        // primitive returns a buffer of full length even on a short read).
         let (record_data, _was_truncated) =
             iso2709::read_record_data(&mut self.reader, record_length, self.recovery_mode)?;
 
-        // Handle truncation in recovery mode. The comparison is preserved
-        // verbatim from the pre-refactor reader: because the buffer is
-        // allocated at full length it is effectively dead today, and
-        // intentionally left so by PR1 to avoid any semantic change.
         if record_data.len() < (record_length - 24) && self.recovery_mode != RecoveryMode::Strict {
             return Err(MarcError::TruncatedRecord(
                 "Holdings record is truncated".to_string(),

--- a/src/iso2709.rs
+++ b/src/iso2709.rs
@@ -1,24 +1,23 @@
 //! Shared ISO 2709 parsing primitives used by all three MARC readers
 //! (bibliographic, authority, holdings).
 //!
-//! This module exists to consolidate the byte-level parsing logic that was
-//! previously duplicated across [`crate::reader`], [`crate::authority_reader`],
-//! and [`crate::holdings_reader`]. Each reader still owns its own record-type
+//! Consolidates the byte-level parsing logic that would otherwise be
+//! duplicated across [`crate::reader`], [`crate::authority_reader`], and
+//! [`crate::holdings_reader`]. Each reader still owns its own record-type
 //! dispatch (which `Record`/`AuthorityRecord`/`HoldingsRecord` to instantiate
 //! and how fields are routed by tag); only the format-level primitives live
 //! here.
 //!
 //! # Scope
 //!
-//! Currently extracted: the I/O loop for reading a leader, the truncation-aware
-//! record-data read, single-entry directory parsing, ASCII numeric helpers, and
-//! the control-field-tag predicate.
+//! Provides the I/O loop for reading a leader, the truncation-aware
+//! record-data read, single-entry directory parsing, ASCII numeric helpers,
+//! and the control-field-tag predicate.
 //!
-//! Not yet extracted: subfield-level parsing. The three readers have subtly
-//! different subfield-parsing semantics (lossy vs strict UTF-8 decoding, error
-//! vs skip on unrecognized bytes) that cannot be unified without a semantic
-//! change. Convergence is deferred to the error-enrichment work where
-//! `ParseContext` will formalize the per-format behavior.
+//! Subfield-level parsing lives in each reader: the bib, authority, and
+//! holdings readers use subtly different semantics (lossy vs strict UTF-8
+//! decoding, error vs skip on unrecognized bytes) that have not been
+//! unified.
 
 use crate::error::{MarcError, Result};
 use crate::recovery::RecoveryMode;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -166,15 +166,13 @@ impl<R: Read> MarcReader<R> {
         // Directory starts after leader, ends at base_address
         let directory_size = base_address - 24;
 
-        // Try to read the full record data; in non-Strict modes, a short read
-        // returns `(buffer, true)` and the recovery branch below dispatches.
+        // Read the full record data. In non-Strict modes a short read returns
+        // `(buffer, true)`; salvage from a partial buffer is not implemented,
+        // so the recovery dispatch below is unreachable in practice (the read
+        // primitive returns a buffer of full length even on a short read).
         let (record_data, _was_truncated) =
             iso2709::read_record_data(&mut self.reader, record_length, self.recovery_mode)?;
 
-        // If the record is truncated and we're in recovery mode, use recovery logic.
-        // Note: this comparison is preserved verbatim from the pre-refactor reader;
-        // because the buffer is allocated at full length it is effectively dead
-        // today, and intentionally left so by PR1 to avoid any semantic change.
         if record_data.len() < (record_length - 24) && self.recovery_mode != RecoveryMode::Strict {
             return crate::recovery::try_recover_record(
                 leader,


### PR DESCRIPTION
## Summary

Source comments and module docs should describe what the code does and why in timeless terms, not the implementation process that produced them. Earlier comments referenced specific PR identifiers, "the error-enrichment work" (a forward reference to in-progress work on a related bead), and "Currently extracted / Not yet extracted" framing — all of which become noise or actively misleading once the related work lands.

## Changes

- `src/iso2709.rs` module docstring: replace "Currently / Not yet" framing with a single declarative description of what's in the module and what stays in each reader (and why)
- `src/reader.rs`, `src/authority_reader.rs`, `src/holdings_reader.rs`: replace three identical comment blocks referencing a specific PR with a single declarative note that the recovery dispatch is unreachable in practice because the read primitive returns a buffer of full length

No code changes; doc-only.

## Test plan

- [x] `.cargo/check.sh --quick` clean locally
- [x] Pre-commit hook ran the check on commit
- [x] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)