### PR TITLE
fix(ci): use nightly toolchain for ASAN -Zbuild-std step

### DIFF
--- a/.github/workflows/memory-safety.yml
+++ b/.github/workflows/memory-safety.yml
@@ -37,6 +37,10 @@ jobs:
           key: ${{ runner.os }}-cargo-asan-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run ASAN on library tests
+        env:
+          # Override rust-toolchain.toml pin so -Zbuild-std uses the nightly
+          # toolchain installed above rather than the stable channel.
+          RUSTUP_TOOLCHAIN: nightly
         run: |
           export RUSTFLAGS="-Z sanitizer=address"
           export LSAN_OPTIONS="suppressions=${{ github.workspace }}/.cargo/asan_suppressions.txt"


### PR DESCRIPTION
## Summary
- ASAN job in `memory-safety.yml` was failing with `error: the -Z flag is only accepted on the nightly channel of Cargo, but this is the stable channel` ([failing run](https://github.com/dchud/mrrc/actions/runs/24649144931/job/72067892509#step:5:19))
- Root cause: `rust-toolchain.toml` pins the channel to `1.95.0` (stable). Even though the workflow installed nightly via `dtolnay/rust-toolchain@nightly`, cargo read the repo's toolchain file and switched back to stable before `-Zbuild-std` was evaluated
- Fix: set `RUSTUP_TOOLCHAIN: nightly` as a step-level env on the ASAN run step so it overrides the pin for just that one step

## Test plan
- [x] Trigger `workflow_dispatch` on this branch and confirm the ASAN job passes