### PR TITLE
fix(ci): set INSTA_WORKSPACE_ROOT so Miri can run insta snapshot tests

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -32,3 +32,6 @@ jobs:
         run: cargo +nightly miri test --lib
         env:
           MIRIFLAGS: -Zmiri-disable-isolation
+          # Prevent insta from spawning `cargo metadata` to discover the
+          # workspace root — Miri can't execute subprocesses (no pidfd_spawnp).
+          INSTA_WORKSPACE_ROOT: ${{ github.workspace }}


### PR DESCRIPTION
## Summary
- Nightly Miri job failed on `error::tests::snapshot_detailed_invalid_indicator_full_context` ([failing run](https://github.com/dchud/mrrc/actions/runs/24655912655/job/72089259017#step:5:472))
- Root cause: `insta::get_cargo_workspace` spawns `cargo metadata` on first call to discover the workspace root. Miri can't execute subprocesses (`extern static pidfd_spawnp is not supported by Miri`), so any insta snapshot test trips it
- Fix: set `INSTA_WORKSPACE_ROOT=${{ github.workspace }}` as env on the Miri step. insta skips the `cargo metadata` spawn entirely when this is set. No code change needed

## Test plan
- [x] Trigger `workflow_dispatch` on this branch and confirm Miri passes