### PR TITLE
fix(ci): use explicit tool input for cargo-fuzz install

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -63,8 +63,10 @@ jobs:
         # Run from the repo root — cargo-fuzz resolves `./fuzz/Cargo.toml`
         # from cwd. `+nightly` overrides the root rust-toolchain.toml pin
         # (1.95.0) with the nightly installed above, which libfuzzer-sys
-        # requires.
-        run: cargo +nightly fuzz run parse_record -- -max_total_time=$MAX_TOTAL_TIME
+        # requires. `--target x86_64-unknown-linux-gnu` overrides cargo-fuzz's
+        # default musl target, which isn't installed on the runner and is
+        # incompatible with `-Zsanitizer=address` (static libc).
+        run: cargo +nightly fuzz run parse_record --target x86_64-unknown-linux-gnu -- -max_total_time=$MAX_TOTAL_TIME
 
       - name: Upload crash artifacts
         if: failure()

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -42,7 +42,9 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
 
       - name: Cache cargo + fuzz target
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary
- Nightly Fuzz workflow failed on run [24873824168](https://github.com/dchud/mrrc/actions/runs/24873824168) with `error: no such command: \`fuzz\`` because the `taiki-e/install-action@cargo-fuzz` shortcut silently produced `##[warning]no tool specified` and installed nothing.
- Switch to the explicit `with: tool: cargo-fuzz` form of `taiki-e/install-action@v2`, which does not depend on ref-name resolution.

## Test plan
- [ ] Next scheduled nightly run (or a manual `workflow_dispatch`) of `Fuzz (nightly)` succeeds at the `Install cargo-fuzz` step and proceeds to `Run parse_record`.