### PR TITLE
fix(ci): docs deploy broken on main — install only the docs extra

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,11 +33,15 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv pip install --system "mrrc[docs]"
+        # `--no-install-project` skips building the mrrc Rust+PyO3 extension
+        # (which would need a Rust toolchain + maturin in this docs-only job).
+        # The `docs` extra in pyproject.toml is the single source of truth for
+        # mkdocs-material, mkdocstrings[python], pymdown-extensions.
+        run: uv sync --extra docs --no-install-project
 
       - name: Build documentation
         # Note: --strict removed until cross-linking fixes are complete (mrrc-s3ug)
-        run: mkdocs build
+        run: uv run mkdocs build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,11 @@ uv run mkdocs serve                           # Live-reload preview at :8000
 
 The `docs` extra in `pyproject.toml` carries `mkdocs-material`,
 `mkdocstrings[python]`, and `pymdown-extensions`. CI installs it via
-`uv pip install --system "mrrc[docs]"`. Do not `uv pip install` these
-ad-hoc — track them in the extra so contributors and CI stay in sync.
+`uv sync --extra docs --no-install-project` — `--no-install-project`
+skips building the mrrc Rust+PyO3 extension, which would require a
+Rust toolchain + maturin in the docs-only job. Do not `uv pip install`
+these ad-hoc — track them in the extra so contributors and CI stay in
+sync.
 
 **Use `uv sync --all-extras`, not `uv sync --extra docs`.** `uv sync`
 is *replacing*, not additive — `--extra docs` alone drops `test` and


### PR DESCRIPTION
## Summary

PR #130 (bd-seja) switched `.github/workflows/docs.yml` to `uv pip install --system "mrrc[docs]"`. That tries to install mrrc itself, which requires building the PyO3 + Rust extension via maturin — but the docs job has neither a Rust toolchain nor maturin set up, so the install line fails silently and the next step errors with `mkdocs: command not found`.

The current breakage is visible on main commit `e006cae` (PR #130 merge): https://github.com/dchud/mrrc/actions/runs/24963294094

## Fix

Use `uv sync --extra docs --no-install-project`. The `docs` extra in `pyproject.toml` stays as the single source of truth; the `--no-install-project` flag pulls only the extras (`mkdocs-material`, `mkdocstrings[python]`, `pymdown-extensions`) without touching the mrrc crate itself. The `mkdocs build` step then runs through `uv run` so the synced venv is on PATH.

Also corrects the corresponding tip in `CLAUDE.md`.

## Mea culpa

In #130 I claimed every other workflow uses `mrrc[<extra>]` as the install pattern. That was wrong — the wheel-test workflows (`python-build.yml`, `python-release.yml`) install `${WHEEL}[<extra>]` against an *already-built* wheel, never against the source tree. None of them ask `uv pip install` to build mrrc on the fly. I should have caught this in the PR review.

## Test plan

- [x] Locally: `uv sync --extra docs --no-install-project && uv run mkdocs build` builds the site cleanly with no Rust toolchain involved (verified by checking that mrrc itself is not installed in the venv after the sync).
- [x] Pre-commit hook ran the full `.cargo/check.sh` — green.
- [ ] Confirm the `Deploy Documentation` workflow goes green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)