### PR TITLE
docs: clean up mkdocs build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   picks them up post-merge. Skipped under `--quick`. Requires the
   `docs` extra (`uv sync --all-extras`); `--strict` mode stays off
   pending mrrc-s3ug.
+- **mkdocs warnings cleanup.** Excluded `docs/history/` (archival per
+  CLAUDE.md, ~90 internal planning artifacts with intentionally stale
+  cross-links) from the published site via `exclude_docs` in
+  `mkdocs.yml`, and removed the corresponding nav entry. Fixed bare
+  `[Unreleased]` / `[X.Y.Z]` references in
+  `docs/contributing/release-procedure.md` that mkdocs-autorefs was
+  treating as broken cross-references. Repointed
+  `docs/tutorials/python/reading-records.md` from a broken
+  `migration-from-pymarc.md#error-handling` link to the
+  `reference/error-handling.md#recovery-modes-and-errors` anchor.
+  Fixed slug typo (`#preflight-dependencies--setup` →
+  `#preflight-dependencies-setup`) and converted the
+  `tests/python/test_query_dsl.py` link in `guides/query-dsl.md` to a
+  GitHub URL since the target lives outside the docs tree.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,19 +151,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs` extra (`uv sync --all-extras`); `--strict` mode stays off
   pending mrrc-s3ug.
 - **mkdocs warnings cleanup.** Excluded `docs/history/` (archival per
-  CLAUDE.md, ~90 internal planning artifacts with intentionally stale
-  cross-links) from the published site via `exclude_docs` in
-  `mkdocs.yml`, and removed the corresponding nav entry. Fixed bare
-  `[Unreleased]` / `[X.Y.Z]` references in
-  `docs/contributing/release-procedure.md` that mkdocs-autorefs was
-  treating as broken cross-references. Repointed
-  `docs/tutorials/python/reading-records.md` from a broken
-  `migration-from-pymarc.md#error-handling` link to the
-  `reference/error-handling.md#recovery-modes-and-errors` anchor.
-  Fixed slug typo (`#preflight-dependencies--setup` →
-  `#preflight-dependencies-setup`) and converted the
-  `tests/python/test_query_dsl.py` link in `guides/query-dsl.md` to a
-  GitHub URL since the target lives outside the docs tree.
+  CLAUDE.md) from the published site, removed its nav entry, and
+  fixed broken cross-links and a stale anchor in active docs. Build
+  warnings down from 18 to 4.
 
 ### Fixed
 

--- a/docs/contributing/release-procedure.md
+++ b/docs/contributing/release-procedure.md
@@ -246,7 +246,7 @@ head -150 CHANGELOG.md
 
 **Checklist**:
 
-- [ ] All recent features are listed in [Unreleased] section
+- [ ] All recent features are listed in `[Unreleased]` section
 - [ ] All breaking changes are documented with migration guidance
 - [ ] All bug fixes are noted
 - [ ] All performance improvements documented
@@ -255,7 +255,7 @@ head -150 CHANGELOG.md
 **Breaking Changes Specific Check**:
 If this release includes breaking changes:
 
-- [ ] **REQUIRED**: Migration guide exists in [Unreleased] or referenced
+- [ ] **REQUIRED**: Migration guide exists in `[Unreleased]` or referenced
 - [ ] **REQUIRED**: Deprecation notices were given in previous release (if applicable)
 - [ ] **REQUIRED**: Major version bump scheduled (e.g., 0.x → 1.0)
 
@@ -320,7 +320,7 @@ Note the reason for the chosen version increment in your release notes/commit me
 
 Update version numbers in all configuration files. **Do this in order** and **verify each file** before proceeding.
 
-The VERSION variable is used throughout. Ensure `$VERSION` is set before starting (see [Preflight Dependencies](#preflight-dependencies--setup)).
+The VERSION variable is used throughout. Ensure `$VERSION` is set before starting (see [Preflight Dependencies](#preflight-dependencies-setup)).
 
 ### 3.1 Update Root Cargo.toml
 
@@ -1022,11 +1022,11 @@ Link to release: https://github.com/dchud/mrrc/releases/tag/vX.Y.Z" \
 
 ### 10.3 Begin Next Development Cycle
 
-After release, update the [Unreleased] section to reflect the next development direction.
+After release, update the `[Unreleased]` section to reflect the next development direction.
 
 **File**: `CHANGELOG.md`
 
-The [Unreleased] section should remain mostly empty with just subsection headers:
+The `[Unreleased]` section should remain mostly empty with just subsection headers:
 
 ```markdown
 ## [Unreleased]
@@ -1049,14 +1049,14 @@ If you have identified planned work items for the next release, create beads iss
 Example workflow:
 1. After release, review roadmap and open issues
 2. Create new issues for planned work: `br create "Feature: ..." -p 2`
-3. Link major items in README roadmap or docs/RELEASES.md (but NOT in CHANGELOG [Unreleased])
-4. The [Unreleased] section fills up organically as work is completed during development
+3. Link major items in README roadmap or docs/RELEASES.md (but NOT in CHANGELOG `[Unreleased]`)
+4. The `[Unreleased]` section fills up organically as work is completed during development
 
 **Why?** CHANGELOG documents what was released, not what's planned. Planning belongs in the issue tracker (beads).
 
 **Checklist**:
 
-- [ ] [Unreleased] section has empty subsections ready for new content
+- [ ] `[Unreleased]` section has empty subsections ready for new content
 - [ ] Major planned work items created as beads issues (not hardcoded in CHANGELOG)
 - [ ] Issue tracker (beads) reflects the development roadmap
 - [ ] README or docs reflect high-level roadmap if needed
@@ -1234,7 +1234,7 @@ twine upload dist/mrrc-*.whl
 
 - [ ] `.cargo/check.sh` passes all checks
 - [ ] Git status is clean
-- [ ] [Unreleased] section is complete and accurate
+- [ ] `[Unreleased]` section is complete and accurate
 - [ ] Breaking changes checked (if any)
 
 **Phase 2: Version Number Selection**
@@ -1251,8 +1251,8 @@ twine upload dist/mrrc-*.whl
 
 **Phase 4: Changelog & Documentation**
 
-- [ ] CHANGELOG.md: [Unreleased] → [X.Y.Z]
-- [ ] New [Unreleased] section created
+- [ ] CHANGELOG.md: `[Unreleased]` → `[X.Y.Z]`
+- [ ] New `[Unreleased]` section created
 - [ ] README.md reviewed and updated
 - [ ] docs/ directory scanned for version refs
 - [ ] Example code compiles and runs
@@ -1291,7 +1291,7 @@ twine upload dist/mrrc-*.whl
 **Phase 9: Post-Release Setup**
 
 - [ ] Beads sync completed
-- [ ] [Unreleased] section cleaned (empty subsections)
+- [ ] `[Unreleased]` section cleaned (empty subsections)
 - [ ] Post-release commit pushed (if any)
 - [ ] Next development issues created (if planned)
 

--- a/docs/guides/query-dsl.md
+++ b/docs/guides/query-dsl.md
@@ -323,4 +323,4 @@ except ValueError as e:
 
 - [MARC 21 Format for Bibliographic Data](https://www.loc.gov/marc/bibliographic/) - Field and indicator definitions
 - [Library of Congress Subject Headings](https://id.loc.gov/authorities/subjects.html) - LCSH (indicator2='0')
-- [tests/python/test_query_dsl.py](../../tests/python/test_query_dsl.py) - Comprehensive test examples
+- [tests/python/test_query_dsl.py](https://github.com/dchud/mrrc/blob/main/tests/python/test_query_dsl.py) - Comprehensive test examples

--- a/docs/tutorials/python/reading-records.md
+++ b/docs/tutorials/python/reading-records.md
@@ -152,7 +152,7 @@ for record in MARCReader("records.mrc", recovery_mode="lenient"):
     print(f"Got {len(record.get_fields())} fields")
 ```
 
-See the [migration guide](../guides/migration-from-pymarc.md#error-handling)
+See the [error handling reference](../../reference/error-handling.md#recovery-modes-and-errors)
 for details on the differences between `permissive` and `recovery_mode`.
 
 ## Complete Example

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,15 @@ site_description: MARC library for Rust and Python
 repo_url: https://github.com/dchud/mrrc
 repo_name: dchud/mrrc
 
+# docs/history/ is archival per CLAUDE.md ("do not modify") — the 90+
+# files there are internal planning artifacts (audits, plan revisions,
+# code-review notes) with intentionally stale cross-links, and they are
+# not user-facing documentation. Kept on disk for `git blame` archeology
+# but excluded from the published site so their stale links don't drown
+# the build log in warnings.
+exclude_docs: |
+  history/
+
 theme:
   name: material
   palette:
@@ -105,7 +114,6 @@ nav:
     - Release Procedure: contributing/release-procedure.md
     - Architecture: contributing/architecture.md
     - Design: design/index.md
-    - History: history/index.md
   - Benchmarks:
     - benchmarks/index.md
     - Results: benchmarks/results.md


### PR DESCRIPTION
## Summary

Reduces mkdocs build warnings from 18 to 4. Pure docs/config changes — no code touched, so this PR also doubles as a live test of #136's `paths-ignore` filter (none of the six per-PR workflows should fire).

### Changes

- **Excluded `docs/history/`** from the published site via `exclude_docs` in `mkdocs.yml`. CLAUDE.md flags it as archival ("do not modify") and the ~90 internal planning artifacts there have intentionally stale cross-links. Files stay on disk for `git blame` archeology.
- **Removed the `History: history/index.md` nav entry** (no other active docs link into `history/`).
- **Wrapped bare `[Unreleased]` / `[X.Y.Z]` references** in `docs/contributing/release-procedure.md` in backticks so mkdocs-autorefs stops treating them as broken cross-references.
- **Repointed `docs/tutorials/python/reading-records.md`** from the broken `../guides/migration-from-pymarc.md#error-handling` link to `../../reference/error-handling.md#recovery-modes-and-errors`.
- **Fixed slug typo** in `docs/contributing/release-procedure.md` (`#preflight-dependencies--setup` → `#preflight-dependencies-setup`).
- **Converted external link in `docs/guides/query-dsl.md`** to `tests/python/test_query_dsl.py` to a GitHub URL since the target lives outside the docs tree.

### Remaining warnings (4, all in `docs/design/profiling/`)

These look archival to me but aren't tagged in CLAUDE.md. Left for a follow-up decision — extending the `exclude_docs` is one line, alternative is to fix the broken refs in-place.

## Test plan

- [x] `mkdocs build` reports 4 warnings (down from 18); zero are in active docs.
- [x] All 9 bare `[Unreleased]` and 1 bare `[X.Y.Z]` autoref triggers fixed.
- [x] Pre-push `.cargo/check.sh --quick` passes.
- [x] **CI fires zero jobs from the six per-PR workflows** (lint/test/build/python-build/benchmark-python/benchmark-rust). Confirms #136's path filter on a real docs-only PR. _Confirmed: `gh run list --branch chore/docs-mkdocs-warnings-cleanup` returned no runs; `gh pr checks 138` reports "no checks reported"._
- [x] Reviewer eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)