### PR TITLE
fix(types): close 2 type-narrowing issues from the bd-mgfg audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Record.to_marc21`, and module-level `__version__` declarations.
   mypy default-mode errors in `mrrc/` dropped 27 → 18; pyright
   16 → 13.
+- **Type-narrowing follow-up from the bd-mgfg audit.** Two more
+  typing-only fixes — runtime behavior unchanged. Wrap
+  `field.data` with `or ''` at the three `add_control_field`
+  call sites (`Record.add_field` /
+  `add_ordered_field` / `add_grouped_field`); the runtime invariant
+  guarantees non-`None` for control fields but the type system can't
+  see it. Switched `_MrrcExceptionBase` to a `TYPE_CHECKING`-gated
+  `Exception` parent so `__cause__` / `__context__` /
+  `__traceback__` resolve cleanly for type checkers; runtime mixin
+  design (parent is `object`) preserved exactly. mypy default-mode
+  errors in `mrrc/` dropped 18 → 10; pyright 13 → 4.
 - **MARCXML reader: missing XML 1.1 §2.11 end-of-line normalization
   in text and CDATA content**
   ([#112](https://github.com/dchud/mrrc/issues/112)). Switched both

--- a/mrrc/__init__.py
+++ b/mrrc/__init__.py
@@ -837,7 +837,7 @@ class Record:
         """Add one or more fields to the record."""
         for field in fields:
             if field.is_control_field():
-                self._inner.add_control_field(field.tag, field.data)
+                self._inner.add_control_field(field.tag, field.data or '')
             else:
                 self._inner.add_field(field._inner)
     
@@ -882,7 +882,7 @@ class Record:
         """Add fields maintaining tag sort order (pymarc compatibility)."""
         for field in fields:
             if field.is_control_field():
-                self._inner.add_control_field(field.tag, field.data)
+                self._inner.add_control_field(field.tag, field.data or '')
             else:
                 existing = list(self._inner.fields())
                 insert_idx = len(existing)
@@ -897,7 +897,7 @@ class Record:
         """Add fields after the last field with the same tag (pymarc compatibility)."""
         for field in fields:
             if field.is_control_field():
-                self._inner.add_control_field(field.tag, field.data)
+                self._inner.add_control_field(field.tag, field.data or '')
                 continue
             existing = list(self._inner.fields())
             last_idx = None

--- a/mrrc/exceptions.py
+++ b/mrrc/exceptions.py
@@ -23,7 +23,20 @@ defense-in-depth measure — unpickling untrusted data remains the relevant
 attack surface regardless.
 """
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
+
+
+# Type-only base for `_MrrcExceptionBase`. At runtime this resolves to
+# ``object`` so the mixin design (separate from the Exception inheritance
+# chain on `MrrcException`) is preserved exactly. At type-check time it
+# resolves to `Exception`, so the type checker sees `__cause__`,
+# `__context__`, and `__traceback__` on instances, and
+# `traceback.format_exception(type(self), self, ...)` calls type-check
+# without needing per-call `cast()` or `# type: ignore`.
+if TYPE_CHECKING:
+    _MixinBase = Exception
+else:
+    _MixinBase = object
 
 
 _POSITIONAL_FIELDS = (
@@ -98,13 +111,15 @@ def _render_hex_dump(
     return "\n".join(lines)
 
 
-class _MrrcExceptionBase:
+class _MrrcExceptionBase(_MixinBase):
     """Mixin providing positional context attributes, formatting, and pickle
     support for every mrrc exception class.
 
     Kept separate from the actual base ``MrrcException`` so subclasses can
     override ``_body_text`` independently of the inheritance chain to
-    Exception itself.
+    Exception itself. The `_MixinBase` parent is `object` at runtime
+    (preserving that separation) and `Exception` at type-check time
+    (so `__cause__` / `__context__` / `__traceback__` resolve cleanly).
     """
 
     # Stable error-code identifiers. Every leaf exception class overrides


### PR DESCRIPTION
## Summary

Two more typing-only fixes from the bd-mgfg audit, follow-on to #139. Runtime behavior is unchanged; all 705 Python tests still pass.

### 1. `add_control_field` type narrowing (3 sites)

`Field.data` is `Optional[str]`; `is_control_field()` returns `bool`, not a `TypeGuard`, so the type checker can't narrow `data` after the check. The runtime invariant (`is_control_field()` ⇔ `_data is not None`) is fine — same idiom is used in `Field.value()` / `format_field()` / `as_marc()` (lines 254-255, 260-261, 428-429): `self._data or ''`.

Apply the same `or ''` at the three Record-side call sites:

```python
self._inner.add_control_field(field.tag, field.data or '')
```

### 2. `_MrrcExceptionBase` Exception inheritance via `TYPE_CHECKING`

`_MrrcExceptionBase` is a mixin — at runtime it inherits `object`; the Exception inheritance comes through `MrrcException(_MrrcExceptionBase, Exception)`. The type checker couldn't see the inherited `__cause__` / `__context__` / `__traceback__` attributes (used in `to_dict()`), and `traceback.format_exception(type(self), self, ...)` didn't resolve.

```python
if TYPE_CHECKING:
    _MixinBase = Exception
else:
    _MixinBase = object

class _MrrcExceptionBase(_MixinBase):
    ...
```

Runtime mixin design preserved exactly. Type-checkers see `_MrrcExceptionBase` as an Exception subclass and the four attribute-access errors plus the `format_exception` overload error all resolve.

## Audit deltas

| Check | Before #139 | After #139 | After this PR |
|---|---|---|---|
| `mypy mrrc/` (default) | 27 | 18 | **10** |
| `mypy mrrc/ --strict` | 84 | 77 | **69** |
| `pyright mrrc/` | 16 | 13 | **4** |

The remaining 10 default-mode errors are different categories (Leader late-binding patches, no-any-return on Rust-bridge calls, an implicit-Optional default, a `dict-item` mismatch). Out of scope for this PR — they'll inform the **permanent-gating decision** that's the next step in bd-mgfg's plan.

## Test plan

- [x] All 705 Python tests pass (no runtime regressions).
- [x] Pre-push `.cargo/check.sh` (full) passes — 535 Rust tests, 705 Python tests, mkdocs build clean.
- [x] mypy + pyright re-run; the target errors gone.
- [ ] CI green on this PR.
- [x] Reviewer eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)