### PR TITLE
fix(types): clear remaining mypy/pyright errors in mrrc/; gate both in check.sh

### DIFF
--- a/.cargo/check.sh
+++ b/.cargo/check.sh
@@ -73,6 +73,14 @@ if [ "$QUICK" = false ]; then
     uv run python -m pytest tests/python/ -m "not benchmark" -q
 
     echo ""
+    echo "=== Python type check (mypy on mrrc/) ==="
+    uv run mypy mrrc/
+
+    echo ""
+    echo "=== Python type check (pyright on mrrc/) ==="
+    uv run pyright mrrc/
+
+    echo ""
     echo "=== Documentation site build (mkdocs) ==="
     # Needs the `docs` extra: run `uv sync --all-extras` if mkdocs is missing.
     # No --strict yet; cross-link fixes are tracked in mrrc-s3ug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,10 +158,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Python typing fidelity improvements.** Stub gaps in `mrrc/_mrrc.pyi`
   closed (`parse_batch_parallel` / `parse_batch_parallel_limited`
   signatures, `Field.delete_subfield`, `Record.to_marc21`,
-  module-level `__version__`) and two wrapper-side narrowing issues
-  fixed (`add_control_field` call sites, `_MrrcExceptionBase`
-  inherited Exception attributes). Type-only — no runtime behavior
-  change.
+  module-level `__version__`) and several wrapper-side narrowing
+  issues fixed. `mypy mrrc/` and `pyright mrrc/` now both report zero
+  errors and run in `.cargo/check.sh` full mode. Type-only — no
+  runtime behavior change.
 - **MARCXML reader: missing XML 1.1 §2.11 end-of-line normalization
   in text and CDATA content**
   ([#112](https://github.com/dchud/mrrc/issues/112)). Switched both

--- a/mrrc/__init__.py
+++ b/mrrc/__init__.py
@@ -141,7 +141,7 @@ class Indicators:
         if isinstance(other, Indicators):
             return self.ind1 == other.ind1 and self.ind2 == other.ind2
         elif isinstance(other, (tuple, list)) and len(other) == 2:
-            return self.ind1 == other[0] and self.ind2 == other[1]
+            return bool(self.ind1 == other[0] and self.ind2 == other[1])
         return False
     
     def __repr__(self) -> str:
@@ -165,7 +165,7 @@ class Field:
     Data fields use indicators and subfields as before.
     """
 
-    def __init__(self, tag: str, indicator1: str = ' ', indicator2: str = ' ', *, subfields=None, indicators=None, data=None):
+    def __init__(self, tag: str, indicator1: str = ' ', indicator2: str = ' ', *, subfields=None, indicators=None, data: Optional[str] = None):
         """Create a new Field.
 
         Args:
@@ -309,7 +309,7 @@ class Field:
 
     def subfields_as_dict(self) -> dict:
         """Return subfields as dictionary mapping code to list of values."""
-        result = {}
+        result: dict[str, list[str]] = {}
         try:
             for sf in self._inner.subfields():
                 code = sf.code
@@ -744,7 +744,7 @@ class Leader:
          """Compare leaders by content."""
          if not isinstance(other, Leader):
              return False
-         return self._rust_leader == other._rust_leader
+         return bool(self._rust_leader == other._rust_leader)
      
      def __hash__(self) -> int:
          """Hash based on rust leader."""
@@ -1341,7 +1341,7 @@ class Record:
     
     def as_dict(self) -> dict:
         """Return pymarc-compatible MARC-in-JSON dict (code4lib schema)."""
-        fields_list = []
+        fields_list: list[dict[str, Any]] = []
         for tag, value in self._inner.control_fields():
             fields_list.append({tag: value})
         for field in self._inner.fields():
@@ -1630,11 +1630,17 @@ def get_leader_is_valid_value(position: int, value: str) -> bool:
     return _Leader.is_valid_value(position, value)
 
 
-# Expose as class methods on the Leader class
-Leader.get_valid_values = staticmethod(get_leader_valid_values)
-Leader.describe_value = staticmethod(get_leader_value_description)
-Leader.is_valid_value = staticmethod(get_leader_is_valid_value)
-Leader.get_value_description = staticmethod(get_leader_value_description)
+# Mirror module-level MARC leader spec helpers onto the Leader class so
+# both `Leader.describe_value(...)` and `mrrc.get_leader_value_description(...)`
+# resolve to the same implementation (which delegates to the Rust Leader).
+# This is a deliberate override of the equivalently-named @classmethods on
+# the Leader class above; the runtime behavior chooses the Rust spec as the
+# single source of truth. mypy / pyright can't see through this assignment
+# pattern, so the per-line ignores below are intentional.
+Leader.get_valid_values = staticmethod(get_leader_valid_values)  # type: ignore[method-assign]
+Leader.describe_value = staticmethod(get_leader_value_description)  # type: ignore[attr-defined]
+Leader.is_valid_value = staticmethod(get_leader_is_valid_value)  # type: ignore[method-assign]
+Leader.get_value_description = staticmethod(get_leader_value_description)  # type: ignore[method-assign]
 
 
 # Format-agnostic reader helper
@@ -1772,7 +1778,7 @@ def write(records, path: Union[str, Any], format: Optional[str] = None) -> int:
 # BIBFRAME Conversion Functions (LOC Linked Data Format)
 # =============================================================================
 
-def marc_to_bibframe(record, config: BibframeConfig = None) -> RdfGraph:
+def marc_to_bibframe(record, config: Optional[BibframeConfig] = None) -> RdfGraph:
     """Convert a MARC record to a BIBFRAME RDF graph.
 
     This function transforms a MARC bibliographic record into a BIBFRAME 2.0

--- a/mrrc/_mrrc.pyi
+++ b/mrrc/_mrrc.pyi
@@ -671,10 +671,10 @@ class ProducerConsumerPipeline:
 
 def parse_batch_parallel(
     boundaries: List[tuple[int, int]],
-    buffer: bytes,
+    buffer: bytes | bytearray,
 ) -> List[Record]: ...
 def parse_batch_parallel_limited(
     boundaries: List[tuple[int, int]],
-    buffer: bytes,
+    buffer: bytes | bytearray,
     limit: int,
 ) -> List[Record]: ...


### PR DESCRIPTION
## Summary

Closes the bd-mgfg audit's permanent-gating decision. Both `mypy mrrc/` (default mode) and `pyright mrrc/` (basic mode) now report zero errors and run as new full-mode steps in `.cargo/check.sh`. Type-only changes — runtime behavior preserved exactly; all 705 Python tests still pass.

## Audit deltas (in `mrrc/`)

| Tool | Audit start | After #139 | After #140 | After this PR |
|---|---|---|---|---|
| mypy default | 27 | 18 | 10 | **0** |
| pyright (basic) | 16 | 13 | 4 | **0** |
| mypy `--strict` | 84 | 77 | 69 | 61 (deferred) |

`mypy --strict`'s remaining 61 errors are mostly missing annotations on helper functions and untyped-call cascades. Permanent strict gating is a longer arc and stays out of `check.sh` for now — could be a follow-up.

## Wrapper fixes (`mrrc/__init__.py`)

- `Field.__init__`: type the `data=` kwarg as `Optional[str] = None`.
- `Indicators.__eq__` tuple/list branch: wrap in `bool()`.
- `Field.subfields_as_dict`: annotate `result: dict[str, list[str]] = {}`.
- `Leader.__eq__`: wrap rust-leader comparison in `bool()`.
- `Record.as_dict`: annotate `fields_list: list[dict[str, Any]] = []`.
- `marc_to_bibframe`: change `config: BibframeConfig = None` to `Optional[BibframeConfig] = None`.
- Leader late-binding block: kept (preserves the runtime override of equivalently-named `@classmethod`s with the module-level helpers that delegate to Rust as the single source of truth) and tagged with per-error `# type: ignore` plus a comment explaining the design.

## Stub fixes (`mrrc/_mrrc.pyi`)

- `parse_batch_parallel` / `parse_batch_parallel_limited`: widen `buffer` from `bytes` to `bytes | bytearray` to match the wrapper signature and the Rust impl's `&[u8]`.

## `check.sh` wiring

Two new steps in full mode (after Python tests, before mkdocs build):

```bash
echo "=== Python type check (mypy on mrrc/) ==="
uv run mypy mrrc/

echo "=== Python type check (pyright on mrrc/) ==="
uv run pyright mrrc/
```

Skipped under `--quick` to keep pre-commit fast (~15s combined runtime; pre-push gates them).

## Test plan

- [x] mypy + pyright both report zero errors against current main.
- [x] All 705 Python tests pass.
- [x] Pre-push `.cargo/check.sh` (full) ran end-to-end including the new typing steps — green.
- [x] CI green on this PR.
- [x] Reviewer eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)