### PR TITLE
chore: replace stale mrrc-s3ug bead refs with timeless comments

### DIFF
--- a/.cargo/check.sh
+++ b/.cargo/check.sh
@@ -83,7 +83,8 @@ if [ "$QUICK" = false ]; then
     echo ""
     echo "=== Documentation site build (mkdocs) ==="
     # Needs the `docs` extra: run `uv sync --all-extras` if mkdocs is missing.
-    # No --strict yet; cross-link fixes are tracked in mrrc-s3ug.
+    # Not run with --strict: pre-existing cross-link warnings under
+    # docs/design/profiling/ would otherwise fail the build.
     uv run mkdocs build
 fi
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,8 @@ jobs:
         run: uv sync --extra docs --no-install-project
 
       - name: Build documentation
-        # Note: --strict removed until cross-linking fixes are complete (mrrc-s3ug)
+        # Not run with --strict: pre-existing cross-link warnings under
+        # docs/design/profiling/ would otherwise fail the build.
         run: uv run mkdocs build
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary

Both `.cargo/check.sh` and `.github/workflows/docs.yml` referenced `mrrc-s3ug` — a placeholder bead ID that was never actually filed. The references violated the **no-process-labels-in-persistent-artifacts** convention (bead IDs belong in commit messages; source/docs comments should describe limitations as properties of the code, not pointers at planning artifacts).

Replaced both with timeless comments:

```
# Not run with --strict: pre-existing cross-link warnings under
# docs/design/profiling/ would otherwise fail the build.
```

When those warnings get resolved (tracked in **bd-8in1**), `--strict` can be enabled and these comments become a one-line removal in each file.

## Test plan

- [x] No `mrrc-s3ug` references remain anywhere in the tree (`grep -rn` returns nothing).
- [x] Pre-push `.cargo/check.sh` (full) passes.
- [ ] CI green on this PR. (Note: this PR touches `.cargo/check.sh` and `.github/workflows/docs.yml` — neither in `paths-ignore`, so the per-PR workflows fire normally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)