### PR TITLE
docs: drop "MARC Rust Crate" phrase; just MRRC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to MRRC (MARC Rust Crate) will be documented in this file.
+All notable changes to MRRC will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# MRRC — MARC Rust Crate
+# MRRC
 
 Rust library for MARC bibliographic records (ISO 2709) with pymarc-compatible
 Python bindings via PyO3/maturin.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to MRRC
 
-Thank you for your interest in contributing to MRRC (MARC Rust Crate)! This document provides guidelines and instructions for getting involved.
+Thank you for your interest in contributing to MRRC! This document provides guidelines and instructions for getting involved.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MRRC: MARC Rust Crate
+# MRRC
 
 [![Tests](https://github.com/dchud/mrrc/actions/workflows/test.yml/badge.svg)](https://github.com/dchud/mrrc/actions/workflows/test.yml)
 [![Lint](https://github.com/dchud/mrrc/actions/workflows/lint.yml/badge.svg)](https://github.com/dchud/mrrc/actions/workflows/lint.yml)

--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,5 @@
 {
-  "projectTitle": "MRRC: MARC Rust Crate",
+  "projectTitle": "MRRC",
   "description": "Rust library for MARC bibliographic records (ISO 2709) with pymarc-compatible Python bindings. Supports JSON, MARCXML, CSV, Dublin Core, MODS, BIBFRAME formats.",
   "folders": ["src", "src-python/src", "mrrc", "docs/getting-started", "docs/tutorials", "docs/guides", "docs/reference", "docs/contributing", "examples"],
   "excludeFolders": ["docs/history", "docs/design", "target", ".beads", ".claude", "tests/data", "benches", "scripts"],

--- a/docs/contributing/release-procedure.md
+++ b/docs/contributing/release-procedure.md
@@ -4,7 +4,7 @@
 **Estimated Duration**: 30-45 minutes for a standard release  
 **Last Updated**: 2026-02-10
 
-This document provides a step-by-step, executable procedure for preparing, testing, and publishing a new release of MRRC (MARC Rust Crate). Follow these steps sequentially to ensure nothing is missed.
+This document provides a step-by-step, executable procedure for preparing, testing, and publishing a new release of MRRC. Follow these steps sequentially to ensure nothing is missed.
 
 ## Quick Start for Agents
 

--- a/docs/guides/migration-from-pymarc.md
+++ b/docs/guides/migration-from-pymarc.md
@@ -1,6 +1,6 @@
 # Migration Guide: pymarc to mrrc
 
-This guide helps existing pymarc users migrate to mrrc (MARC Rust Crate), a high-performance Rust-based MARC library with Python bindings.
+This guide helps existing pymarc users migrate to mrrc, a high-performance Rust-based MARC library with Python bindings.
 
 ## Overview
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 // without addressing a real performance concern (errors are off the hot path).
 #![allow(clippy::result_large_err)]
 
-//! # MRRC: MARC Rust Crate
+//! # MRRC
 //!
 //! A high-performance Rust library for reading, writing, and manipulating MARC bibliographic
 //! records in the ISO 2709 binary format.


### PR DESCRIPTION
## Summary

Drop the "MARC Rust Crate" appositive everywhere active — it didn't capture anything the actual project description below each occurrence wasn't already saying. The project name is just **mrrc** (or **MRRC** in titles).

8 active files, 1 occurrence each:

| Pattern | Files |
|---|---|
| Title heading: `# MRRC: MARC Rust Crate` → `# MRRC` | `README.md`, `src/lib.rs` |
| Title heading: `# MRRC — MARC Rust Crate` → `# MRRC` | `CLAUDE.md` |
| JSON value: `"MRRC: MARC Rust Crate"` → `"MRRC"` | `context7.json` |
| Parenthetical: `MRRC (MARC Rust Crate)` → `MRRC` | `CHANGELOG.md`, `docs/contributing/release-procedure.md`, `docs/guides/migration-from-pymarc.md`, `CONTRIBUTING.md` |

The 4 archival files in `docs/history/` that mention it are untouched per CLAUDE.md ("docs/history/ — archival only, do not modify"). Those files are also excluded from the published mkdocs site (since #138), so end users don't see the phrase there either.

## Test plan

- [x] Pre-push `.cargo/check.sh` (full) passes — 535 Rust tests, doc tests, mypy/pyright clean, mkdocs build clean.
- [x] No remaining "MARC Rust Crate" references outside `docs/history/` and the gitignored `site/` build output.
- [ ] CI green on this PR.
- [x] Reviewer eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)