### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+## [0.8.0] - 2026-04-29
+
 ### Breaking
 
 - **`MarcError` variants restructured to struct form** carrying

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Pre-built Python wheels are available for:
 
 ## Roadmap
 
-Version 0.7.0 is suitable for testing but remains experimental. Before a 1.0 release, we plan to complete:
+Version 0.8.0 is suitable for testing but remains experimental. Before a 1.0 release, we plan to complete:
 
 1. **Real-world data testing** — Validate against large-scale MARC datasets from LOC, Internet Archive, and other sources to discover edge cases
 2. **Code review** — Thorough review of the codebase, particularly the Rust core and `PyO3` bindings

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,7 +39,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mrrc = "0.7"
+mrrc = "0.8"
 ```
 
 Or with cargo:

--- a/docs/getting-started/quickstart-rust.md
+++ b/docs/getting-started/quickstart-rust.md
@@ -6,7 +6,7 @@ Get started with MRRC in Rust in 5 minutes.
 
 ```toml
 [dependencies]
-mrrc = "0.7"
+mrrc = "0.8"
 ```
 
 ## Read Records

--- a/docs/tutorials/rust/concurrency.md
+++ b/docs/tutorials/rust/concurrency.md
@@ -16,7 +16,7 @@ Add Rayon to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mrrc = "0.6"
+mrrc = "0.8"
 rayon = "1.8"
 ```
 


### PR DESCRIPTION
## Summary

Prepare v0.8.0 release per **`docs/contributing/release-procedure.md`** (sections P–6, plus §7.1 commit). After review and merge, you'll do §7.2–§7.3 (tag + push) and `python-release.yml` handles publishing to PyPI / crates.io / GitHub Releases.

> **Process note:** initial commit followed an abbreviated 1–4 outline rather than the full procedure. The follow-up commit (`b0c2e7a`) catches up by running the rest of §1.3 / §5.1 / §5.3 / §5.4 / §P.2 — finds and fixes the stale README "Version 0.7.0" line. Saved as a feedback memory so I follow the full process next time.

## Step-by-step audit against the procedure

### §P — Preflight
- [x] **§P.1** Repo root: confirmed.
- [x] **§P.2** Required tools: rustc 1.95.0, cargo 1.95.0, python 3.12.8, uv 0.11.8.
- [ ] **§P.3** Publishing creds — deferred to your tag-push step (PyPI OIDC at pypi.org and crates.io token).
- [x] **§P.4** VERSION = `0.8.0`.

### §1 — Pre-Release Verification
- [x] **§1.1** Full `.cargo/check.sh` passes — 535 Rust tests, 705 Python tests, mypy + pyright clean, mkdocs build succeeds (only pre-existing `design/profiling/` warnings remain, tracked in bd-8in1).
- [x] **§1.2** Working tree clean.
- [x] **§1.3** CHANGELOG completeness: `[0.8.0]` section covers all major work since v0.7.6 — structured errors / typed exceptions / stable error codes / per-stream error cap / authority+holdings recovery parity / shared ISO 2709 skeleton / property tests / cargo-fuzz / MARCXML EOL fix / inline-perf recovery / pinned 1.95.0 toolchain / CI cleanup / typing gates. Breaking changes have migration guidance (match on `.code()` for stable identity).
- [x] **§1.4** `bash scripts/lint-changelog.sh` passes.

### §2 — Version Number Selection
- [x] **0.7.6 → 0.8.0** is a minor bump per pre-1.0 SemVer (breaking changes allowed). Justified by the documented `### Breaking` items: `MarcError` variant restructure, `MarcError::InvalidRecord`/`ParseError` removals, `recovery::RecoveryContext` removal, `recovery::try_recover_record` arity change.

### §3 — Update Configuration Files
- [x] **§3.1** `Cargo.toml`: already `0.8.0` (bumped during cycle in `358e796`).
- [x] **§3.2** `src-python/Cargo.toml`: already `0.8.0`.
- [x] **§3.3** `pyproject.toml`: already `0.8.0`.
- [x] **§3.4** All match. `Cargo.lock` (mrrc + mrrc-python) and `uv.lock` (mrrc package entry) also at `0.8.0`.

### §4 — Update Changelog
- [x] **§4.1** Validate structure: confirmed.
- [x] **§4.2** Created release entry: `## [Unreleased]` (fresh, with Added/Changed/Fixed scaffolds) above `## [0.8.0] - 2026-04-29` (which holds the v0.8 content).
- [x] **§4.3** Verify structure: one `[Unreleased]`, one `[0.8.0]`, lint passes.

### §5 — Update Documentation
- [x] **§5.1** README.md: bumped roadmap "Version 0.7.0 is suitable for testing" → "Version 0.8.0…". Initially missed; caught in the follow-up audit.
- [x] **§5.2** docs/ directory:
  - `docs/getting-started/installation.md:42` — `mrrc = "0.7"` → `"0.8"`
  - `docs/getting-started/quickstart-rust.md:9` — `mrrc = "0.7"` → `"0.8"`
  - `docs/tutorials/rust/concurrency.md:19` — `mrrc = "0.6"` → `"0.8"` (was stale before this cycle; opportunistically caught)
- [x] **§5.3** `cargo build --examples` succeeds.
- [x] **§5.4** AGENTS.md: scanned, no stale version/release/publish references.

### §6 — Final Sanity Check
- [x] **§6.0** Final verification: full check.sh re-run after README fix — green.
- [x] **§6.1** No `.bak` files (didn't use sed -i.bak).

### §7 — Git Operations (you do these post-merge)
- [x] **§7.1** Commit prepared: `chore(release): v0.8.0` (`025b6b8`) plus the README catch-up (`b0c2e7a`).
- [ ] **§7.2** Tag: `git tag -a v0.8.0 -m "Release version 0.8.0"`.
- [ ] **§7.3** Push: `git push origin main && git push origin v0.8.0`.

## After tag push

`python-release.yml` triggers automatically:
- Builds wheels for `{ubuntu, macos, windows} × {3.10, 3.11, 3.12, 3.13, 3.14}` (15) plus `{aarch64, i686}-linux × 5` cross-compiled (10) = 25 wheels.
- Tests each wheel.
- Publishes to PyPI via OIDC trusted publishing.
- Creates the GitHub Release with notes auto-extracted from `[0.8.0]` in CHANGELOG.

`cargo publish` for crates.io is manual — `cargo publish --dry-run` then `cargo publish` whenever you're ready (procedure §8.3).

## Test plan

- [x] All version files at 0.8.0.
- [x] CHANGELOG lint passes.
- [x] cargo-semver-checks against v0.7.6 baseline — clean (verified in #143).
- [x] No stale `mrrc = "0.x"` in active docs.
- [x] No stale "Version 0.7.x" in README.md.
- [x] `cargo build --examples` succeeds.
- [x] Full `.cargo/check.sh` (post-README-fix) green.
- [ ] CI green on this PR.
- [ ] Reviewer eyeball pass on the CHANGELOG `[0.8.0]` section as it'll appear in the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)