### PR TITLE
fix(error): preserve positional context on InvalidLeader (E002)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -751,6 +751,141 @@ impl MarcError {
         self
     }
 
+    /// Populate the positional-context fields (`record_index`,
+    /// `byte_offset`, `record_byte_offset`, `source_name`) on this error
+    /// from `ctx`. Used at call sites that construct `MarcError` outside
+    /// the `ParseContext::err_*` helper family — most commonly the
+    /// leader-validation path, where `Leader::from_bytes` /
+    /// `validate_for_reading` build errors directly via the crate-private
+    /// `leader_msg` constructor and the skeleton then enriches them.
+    ///
+    /// Variants that don't carry one of these fields skip that field
+    /// silently. Variants that already have a field set are
+    /// overwritten.
+    #[must_use]
+    pub fn with_position(mut self, ctx: &crate::iso2709::ParseContext) -> Self {
+        let ridx = if ctx.record_index == 0 {
+            None
+        } else {
+            Some(ctx.record_index)
+        };
+        *self.record_index_mut() = ridx;
+        if let Some(slot) = self.byte_offset_mut() {
+            *slot = Some(ctx.stream_byte_offset);
+        }
+        if let Some(slot) = self.record_byte_offset_mut() {
+            *slot = Some(ctx.record_byte_offset());
+        }
+        if let Some(slot) = self.source_name_mut() {
+            slot.clone_from(&ctx.source_name);
+        }
+        self
+    }
+
+    /// Mutable reference to the `record_index` field. Every variant
+    /// carries this field, so the return type is unconditional.
+    fn record_index_mut(&mut self) -> &mut Option<usize> {
+        match self {
+            MarcError::InvalidLeader { record_index, .. }
+            | MarcError::RecordLengthInvalid { record_index, .. }
+            | MarcError::BaseAddressInvalid { record_index, .. }
+            | MarcError::BaseAddressNotFound { record_index, .. }
+            | MarcError::DirectoryInvalid { record_index, .. }
+            | MarcError::TruncatedRecord { record_index, .. }
+            | MarcError::EndOfRecordNotFound { record_index, .. }
+            | MarcError::InvalidIndicator { record_index, .. }
+            | MarcError::BadSubfieldCode { record_index, .. }
+            | MarcError::InvalidField { record_index, .. }
+            | MarcError::EncodingError { record_index, .. }
+            | MarcError::FieldNotFound { record_index, .. }
+            | MarcError::IoError { record_index, .. }
+            | MarcError::XmlError { record_index, .. }
+            | MarcError::JsonError { record_index, .. }
+            | MarcError::WriterError { record_index, .. }
+            | MarcError::FatalReaderError { record_index, .. } => record_index,
+        }
+    }
+
+    /// Mutable reference to the `byte_offset` field, or `None` for
+    /// variants that don't carry one (`FieldNotFound`, `WriterError`,
+    /// `FatalReaderError`).
+    fn byte_offset_mut(&mut self) -> Option<&mut Option<usize>> {
+        match self {
+            MarcError::InvalidLeader { byte_offset, .. }
+            | MarcError::RecordLengthInvalid { byte_offset, .. }
+            | MarcError::BaseAddressInvalid { byte_offset, .. }
+            | MarcError::BaseAddressNotFound { byte_offset, .. }
+            | MarcError::DirectoryInvalid { byte_offset, .. }
+            | MarcError::TruncatedRecord { byte_offset, .. }
+            | MarcError::EndOfRecordNotFound { byte_offset, .. }
+            | MarcError::InvalidIndicator { byte_offset, .. }
+            | MarcError::BadSubfieldCode { byte_offset, .. }
+            | MarcError::InvalidField { byte_offset, .. }
+            | MarcError::EncodingError { byte_offset, .. }
+            | MarcError::IoError { byte_offset, .. }
+            | MarcError::XmlError { byte_offset, .. }
+            | MarcError::JsonError { byte_offset, .. } => Some(byte_offset),
+            MarcError::FieldNotFound { .. }
+            | MarcError::WriterError { .. }
+            | MarcError::FatalReaderError { .. } => None,
+        }
+    }
+
+    /// Mutable reference to the `record_byte_offset` field, or `None`
+    /// for variants whose failure precedes per-record offset semantics
+    /// (the leader-shape variants) or have no record context
+    /// (accessor / writer / format / I/O variants).
+    fn record_byte_offset_mut(&mut self) -> Option<&mut Option<usize>> {
+        match self {
+            MarcError::InvalidLeader {
+                record_byte_offset, ..
+            }
+            | MarcError::DirectoryInvalid {
+                record_byte_offset, ..
+            }
+            | MarcError::TruncatedRecord {
+                record_byte_offset, ..
+            }
+            | MarcError::EndOfRecordNotFound {
+                record_byte_offset, ..
+            }
+            | MarcError::InvalidIndicator {
+                record_byte_offset, ..
+            }
+            | MarcError::BadSubfieldCode {
+                record_byte_offset, ..
+            }
+            | MarcError::InvalidField {
+                record_byte_offset, ..
+            } => Some(record_byte_offset),
+            _ => None,
+        }
+    }
+
+    /// Mutable reference to the `source_name` field, or `None` for
+    /// variants that don't carry one.
+    fn source_name_mut(&mut self) -> Option<&mut Option<String>> {
+        match self {
+            MarcError::InvalidLeader { source_name, .. }
+            | MarcError::RecordLengthInvalid { source_name, .. }
+            | MarcError::BaseAddressInvalid { source_name, .. }
+            | MarcError::BaseAddressNotFound { source_name, .. }
+            | MarcError::DirectoryInvalid { source_name, .. }
+            | MarcError::TruncatedRecord { source_name, .. }
+            | MarcError::EndOfRecordNotFound { source_name, .. }
+            | MarcError::InvalidIndicator { source_name, .. }
+            | MarcError::BadSubfieldCode { source_name, .. }
+            | MarcError::InvalidField { source_name, .. }
+            | MarcError::EncodingError { source_name, .. }
+            | MarcError::IoError { source_name, .. }
+            | MarcError::XmlError { source_name, .. }
+            | MarcError::JsonError { source_name, .. } => Some(source_name),
+            MarcError::FieldNotFound { .. }
+            | MarcError::WriterError { .. }
+            | MarcError::FatalReaderError { .. } => None,
+        }
+    }
+
     /// Canonical docs URL for this error code, pointing at the `#Exxx`
     /// anchor on the error-codes reference page.
     ///

--- a/src/iso2709_skeleton.rs
+++ b/src/iso2709_skeleton.rs
@@ -189,14 +189,21 @@ where
     ctx.begin_record();
 
     // Leader errors bypass ParseContext (Leader::from_bytes builds MarcError
-    // directly); enrich any raised error with a byte window around the leader
-    // bytes for hex-dump rendering.
+    // directly via leader_msg); enrich any raised error with positional
+    // context from the live ParseContext plus a byte window around the
+    // leader bytes for hex-dump rendering. Without with_position, callers
+    // see InvalidLeader (E002) without record_index / byte_offset /
+    // record_byte_offset / source_name — the structured-positional-context
+    // promise of the v0.8 error work.
     let leader_offset = ctx.stream_byte_offset;
-    let leader = Leader::from_bytes(&leader_bytes)
-        .map_err(|e| e.with_bytes_near(&leader_bytes, leader_offset))?;
-    leader
-        .validate_for_reading()
-        .map_err(|e| e.with_bytes_near(&leader_bytes, leader_offset))?;
+    let leader = Leader::from_bytes(&leader_bytes).map_err(|e| {
+        e.with_position(ctx)
+            .with_bytes_near(&leader_bytes, leader_offset)
+    })?;
+    leader.validate_for_reading().map_err(|e| {
+        e.with_position(ctx)
+            .with_bytes_near(&leader_bytes, leader_offset)
+    })?;
 
     B::validate_record_type(&leader, ctx)?;
 

--- a/tests/error_coverage.toml
+++ b/tests/error_coverage.toml
@@ -92,7 +92,7 @@ slug = "leader_invalid"
 trigger_kind = "parse_iso2709"
 trigger_fixture = "tests/data/error_fixtures/e002_indicator_count_non_digit.bin"
 description = "Leader byte 10 (indicator count, normally '2') replaced with 'X'."
-expected_context = ["bytes_near"]
+expected_context = ["record_index", "byte_offset", "record_byte_offset", "bytes_near"]
 recovery_modes = ["strict"]
 wired = true
 


### PR DESCRIPTION
## Summary

The leader-validation path constructs `MarcError::InvalidLeader` via the crate-private `leader_msg` helper, which discards every positional field (`record_index`, `byte_offset`, `record_byte_offset`, `source_name` set to `None`). The skeleton caller enriched `bytes_near` after the fact but not the rest — so `InvalidLeader` errors emit with hex-dump context but missing the metadata most useful for "where in the harvest is this bad record?" The structured-positional-context promise of the v0.8 error work didn't hold for this variant.

Three pieces:

1. New **`MarcError::with_position(&ParseContext)`** builder mirrors the existing `with_bytes_near` pattern: takes a live `ParseContext` and populates `record_index` / `byte_offset` / `record_byte_offset` / `source_name` on whichever subset of those fields the variant carries. Variants without a given field skip silently.

2. Implemented via four small per-field mut accessors (`record_index_mut` / `byte_offset_mut` / `record_byte_offset_mut` / `source_name_mut`) that mirror the existing immutable accessors. Keeps `with_position` trivial and the per-field variant lists close to one place — chosen over a single 116-line match expression that tripped `clippy::too_many_lines`.

3. Skeleton's leader-validation `map_err` chain now calls `.with_position(ctx)` before `.with_bytes_near(...)` so the error inherits the live `ParseContext` state that `begin_record()` set up.

## Coverage harness

`tests/error_coverage.toml` expands the E002 case's `expected_context` from `["bytes_near"]` alone to include `record_index`, `byte_offset`, and `record_byte_offset`. Both Rust and Python harnesses assert; tally unchanged at `9/18 wired` (this PR sharpens what an already-wired case asserts rather than adding a new wired case).

## Side effect for upcoming work

The fix benefits any future variants reached via the same `map_err` chain. When **bd-44z4** lands E001/E003/E004/E006 wiring (those codes currently collapse to E002 via the same `leader_msg` path), they'll inherit positional context from this same chain without further plumbing.

## Bead linkage

bd-0x73.2 (Phase B Rust-core fix). Closes once this PR merges and CI is green on all platforms.

## Test plan

- [x] CI is green on this PR (full check.sh, all platforms, Python 3.10–3.14). _**24 of 25 substantive checks pass.** The one failure is `CodSpeed Performance Analysis` (the dashboard-side cross-machine analysis, distinct from `Codspeed Performance Regression Detection` which passed). CodSpeed's own report on this PR flags two warnings: "Unknown Walltime execution environment detected" and "Different runtime environments detected" — exactly the cross-machine noise problem that motivated building the same-runner perf gate. The flagged "regressions" are all in parallel benchmarks (`test_pipeline_*`, `test_parallel_*`) that this PR doesn't touch — error-path-only changes can't affect happy-path parallel timings. Recommendation: acknowledge in CodSpeed UI and merge based on the trustworthy gate's signal._
- [x] `error-handling-perf-gate.yml` reports near-0% delta. _Same-runner before/after on Ubuntu CI: `parse_10k_clean_strict -1.30%`, `parse_10k_bad_indicators_strict -0.55%`, both `ok` (within ±2%). Confirms changes are confined to the error path._
- [x] `cargo test --test error_coverage` — E002 case asserts the four expected_context fields. _Verified locally; harness reports `wired in manifest: 9/18 | harness asserted: 5/9` (unchanged tally; this PR sharpens what an already-wired case asserts)._
- [x] `uv run python -m pytest tests/python/test_error_coverage.py -k e002 -v` — E002 passes through the FFI. _Verified locally; full harness `8 passed, 12 skipped`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
