### PR TITLE
fix(error): wire E202 BadSubfieldCode in parse_subfields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accepted as-is. In lenient and permissive modes the offending field
   is dropped and the recovery cap is incremented; strict mode
   propagates the error.
+- Subfield code bytes are now validated in `parse_subfields`: each
+  must be printable non-space ASCII (matches MARC 21 a-z / 0-9
+  conventions and rejects NUL, control bytes, space, and high
+  bytes). A different byte fires `BadSubfieldCode` (E202) carrying
+  `field_tag` and the offending `subfield_code`. Previously the
+  byte was cast to char and accepted as-is. Recovery-mode dispatch
+  matches E201's shape: lenient and permissive drop the field via
+  the existing cap path; strict propagates.
 - Strict-mode parsing now verifies that the byte at the leader's
   claimed end-of-record position is `RECORD_TERMINATOR` (0x1D); a
   different byte fires `EndOfRecordNotFound` (E006). Previously the

--- a/src/iso2709.rs
+++ b/src/iso2709.rs
@@ -702,7 +702,14 @@ pub fn parse_subfields(
         if pos >= bytes.len() {
             break;
         }
-        let code = bytes[pos] as char;
+        let code_byte = bytes[pos];
+        // Subfield codes must be printable, non-space ASCII per MARC 21
+        // (`is_ascii_graphic` covers a-z / 0-9 plus punctuation; rejects
+        // NUL, control bytes, space, and high bytes).
+        if !code_byte.is_ascii_graphic() {
+            return Err(ctx.err_bad_subfield_code(code_byte));
+        }
+        let code = code_byte as char;
         pos += 1;
         let mut end = pos;
         while end < bytes.len()

--- a/tests/error_coverage.toml
+++ b/tests/error_coverage.toml
@@ -271,8 +271,7 @@ expected_context = [
     "subfield_code",
 ]
 recovery_modes = ["strict"]
-wired = false
-skip_reason = "parse_subfields accepts any byte as a subfield code; no parse path constructs BadSubfieldCode"
+wired = true
 
 # === Encoding (E3xx) ================================================
 


### PR DESCRIPTION
## Summary

- `parse_subfields` validates each subfield-code byte with `is_ascii_graphic()` (matches MARC 21 a-z / 0-9 conventions; rejects NUL, control bytes, space, and high bytes).
- A non-conforming byte fires `MarcError::BadSubfieldCode` (E202) carrying `field_tag`, `subfield_code`, and the full positional context via `ParseContext::err_bad_subfield_code`.
- Recovery-mode dispatch matches E201's shape: strict propagates; lenient and permissive drop the field and increment `RecoveryCap` via the skeleton's existing parse-data-field error-handler.

## Coverage harness ratchet

`tests/error_coverage.toml` flips `e202_non_printable_subfield_code` from `wired = false` → `wired = true`. Manifest tally: 16/18 → 17/18.

## Perf

Same hot-path location as E201 — one `is_ascii_graphic` check per subfield code, scaling with subfield count per record. Local `parse_10k_clean_strict` shows no measurable cost vs v0.8.0 baseline. CI same-runner perf gate cleared cleanly (all 25 checks green).

## Context

Second of three PRs finishing the unwired-codes manifest. Same TDD ratchet pattern as E201 (#170). Final PR (E301 — UTF-8 strict path via the holdings reader) needs a holdings-record fixture rather than new detection logic, so it has a different shape.

After E301 lands the manifest is at 18/18 wired (zero gaps between docs and parser), unblocking bd-0x73.12's release-readiness gate.

## Test plan

- [x] `.cargo/check.sh` passes locally
- [x] `cargo test --test error_coverage` asserts E202 in Rust harness
- [x] Python harness picks up the manifest flip automatically
- [x] All 538 lib tests pass — no fixtures with non-printable subfield codes
- [x] CI passes on all platforms (25/25 green)
- [x] Perf gate: `clean_strict` near-baseline (E202's check is on the same hot path as E201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)