### PR TITLE
Remove dead leader err_* helpers, annotate writer u32 guards

### DIFF
--- a/src/iso2709.rs
+++ b/src/iso2709.rs
@@ -185,58 +185,6 @@ impl ParseContext {
         BytesNear::capture(buffer, base, self.stream_byte_offset)
     }
 
-    /// Construct an [`MarcError::RecordLengthInvalid`] inheriting the current
-    /// stream/record positional state.
-    #[must_use]
-    pub fn err_record_length_invalid(
-        &self,
-        found: Option<&[u8]>,
-        expected: impl Into<String>,
-    ) -> MarcError {
-        let found_bytes = found.map(crate::error::truncate_bytes);
-        MarcError::RecordLengthInvalid {
-            record_index: self.record_index_opt(),
-            byte_offset: Some(self.stream_byte_offset),
-            source_name: self.source_name.clone(),
-            found: found_bytes,
-            expected: Some(expected.into()),
-            bytes_near: self.capture_bytes_near(),
-        }
-    }
-
-    /// Construct an [`MarcError::BaseAddressInvalid`] inheriting the current
-    /// stream/record positional state.
-    #[must_use]
-    pub fn err_base_address_invalid(
-        &self,
-        found: Option<&[u8]>,
-        expected: impl Into<String>,
-    ) -> MarcError {
-        let found_bytes = found.map(crate::error::truncate_bytes);
-        MarcError::BaseAddressInvalid {
-            record_index: self.record_index_opt(),
-            byte_offset: Some(self.stream_byte_offset),
-            source_name: self.source_name.clone(),
-            record_control_number: self.record_control_number.clone(),
-            found: found_bytes,
-            expected: Some(expected.into()),
-            bytes_near: self.capture_bytes_near(),
-        }
-    }
-
-    /// Construct an [`MarcError::BaseAddressNotFound`] inheriting the
-    /// current stream/record positional state.
-    #[must_use]
-    pub fn err_base_address_not_found(&self) -> MarcError {
-        MarcError::BaseAddressNotFound {
-            record_index: self.record_index_opt(),
-            byte_offset: Some(self.stream_byte_offset),
-            source_name: self.source_name.clone(),
-            record_control_number: self.record_control_number.clone(),
-            bytes_near: self.capture_bytes_near(),
-        }
-    }
-
     /// Construct an [`MarcError::DirectoryInvalid`] inheriting the current
     /// stream/record positional state.
     #[must_use]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -217,7 +217,16 @@ impl<W: Write> MarcWriter<W> {
             record_control_number.as_deref(),
         )?;
 
-        // Update leader with correct values
+        // Update leader with correct values.
+        //
+        // These two `u32::try_from` checks are redundant runtime guards. The
+        // `check_iso2709_size` call above already caps both `record_length` and
+        // `base_address` at `ISO2709_MAX_FIELD` (99_999), far below `u32::MAX`,
+        // so neither conversion can fail today and the error arms are
+        // unreachable from the public API. They are kept deliberately: if a
+        // future refactor ever reaches this leader-population step without first
+        // routing through `check_iso2709_size`, these guards still prevent a
+        // silent `usize`→`u32` truncation on 64-bit hosts.
         let mut leader = record.leader.clone();
         leader.record_length =
             u32::try_from(record_length).map_err(|_| MarcError::WriterError {


### PR DESCRIPTION
Dead defensive code cleanup from the error-handling quality review (Phase 1 cross-cutting finding #1, plus the writer.rs finding surfaced by PR #212).

## ParseContext err_* helpers — deleted (3)

`err_record_length_invalid`, `err_base_address_invalid`, and `err_base_address_not_found` had zero callers. Their error firing sites live in `Leader::from_bytes` and `Leader::validate_for_reading` — low-level `Leader` methods with no `ParseContext` in scope. The ISO 2709 / JSON / marcjson parse paths enrich those errors after the fact via `e.with_position(ctx).with_bytes_near(...)`, so the helpers can't be folded into the firing sites and are genuinely redundant. Decision: delete (option b).

The originally-listed `err_io` is no longer dead — it gained a caller in the E007 IoError enrichment work (PR #222), so it stays.

## writer.rs u32 conversion guards — kept with a comment (option c)

The two `u32::try_from` checks in `MarcWriter::write_record` are redundant runtime guards: `check_iso2709_size` (called immediately before) already caps both `record_length` and `base_address` at `ISO2709_MAX_FIELD` (99_999), far below `u32::MAX`, so the error arms are unreachable from the public API. They're kept with a comment because they still prevent a silent `usize`→`u32` truncation if a future refactor reaches the leader-population step without routing through `check_iso2709_size` first.

## Verification

`.cargo/check.sh` green (rustfmt, clippy core + python, ruff, 564 Rust tests, doc tests, mkdocs build). Audit confirms zero remaining `ParseContext::err_*` helpers without callers.

Closes #208

Bead: bd-0x73.21.4