### PR TITLE
Fix stale byte_offset and missing field_tag in data-field minimum-bytes guard

### DIFF
--- a/src/authority_reader.rs
+++ b/src/authority_reader.rs
@@ -491,6 +491,51 @@ mod tests {
     }
 
     #[test]
+    fn test_authority_field_too_short_error_carries_field_offset_and_tag() {
+        // A 100 data field with a 1-byte data area trips the per-reader
+        // minimum-bytes guard (authority's `< 2`). The raised InvalidField must
+        // carry the offending field's tag and a byte_offset pointing at the
+        // field's data-area start — not the directory entry the parser was last
+        // walking. Regression for the guard inheriting stale ctx positional
+        // state (tag 100, len 0001, start 0).
+        let mut directory = Vec::new();
+        directory.extend_from_slice(b"100000100000");
+        directory.push(FIELD_TERMINATOR);
+        let bytes = build_authority_record_with(&directory, b"x");
+
+        // The data area begins at the leader's base address; with start_position
+        // 0 the field's absolute offset equals base_address. The buggy path
+        // reported the directory entry's offset (24) and a null field_tag.
+        let base_address = 24 + directory.len();
+
+        let mut reader =
+            AuthorityMarcReader::new(Cursor::new(bytes)).with_recovery_mode(RecoveryMode::Strict);
+        let err = reader
+            .read_record()
+            .expect_err("field below the 2-byte minimum must error in strict mode");
+
+        match err {
+            MarcError::InvalidField {
+                field_tag,
+                byte_offset,
+                ..
+            } => {
+                assert_eq!(
+                    field_tag.as_deref(),
+                    Some("100"),
+                    "field_tag should identify the offending field"
+                );
+                assert_eq!(
+                    byte_offset,
+                    Some(base_address),
+                    "byte_offset should point at the field's data-area start, not the directory entry"
+                );
+            },
+            other => panic!("expected InvalidField, got: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_authority_max_errors_cap_trips_on_field_length_failures() {
         // Each record has one bad-field-length entry → one note_recovery_error
         // per record. Cap of 3 means the 4th read trips.

--- a/src/iso2709_skeleton.rs
+++ b/src/iso2709_skeleton.rs
@@ -495,8 +495,20 @@ where
             continue;
         }
 
+        // Point stream_byte_offset at the field's absolute start and record
+        // the field's tag before the per-reader guard runs, so any error the
+        // guard raises carries a precise byte_offset (the field's data-area
+        // position, not the directory entry) and the correct field_tag. The
+        // same state also feeds parse_data_field below for hex-dump caret
+        // alignment.
+        ctx.current_field_tag = tag.as_bytes().try_into().ok();
+        ctx.stream_byte_offset = record_data_offset + data_start + start_position;
+
         // Per-reader minimum-bytes guard (authority's `< 2`, holdings' `< 3`).
         if let Err(e) = B::validate_data_field_bytes(field_data, &tag, ctx) {
+            // Clear field context so it doesn't leak into the next iteration
+            // on the lenient skip-continue path (mirrors the reset below).
+            ctx.current_field_tag = None;
             if recovery_mode == RecoveryMode::Strict {
                 return Err(e);
             }
@@ -505,11 +517,7 @@ where
             continue;
         }
 
-        // Data field. Point stream_byte_offset at the field's absolute start
-        // so any error raised inside parse_data_field carries a precise
-        // byte_offset for hex-dump caret alignment.
-        ctx.current_field_tag = tag.as_bytes().try_into().ok();
-        ctx.stream_byte_offset = record_data_offset + data_start + start_position;
+        // Data field.
         let parsed = parse_data_field(field_data, &tag, B::parse_config(validation_level), ctx);
         ctx.current_field_tag = None;
         match parsed {

--- a/tests/error_coverage.toml
+++ b/tests/error_coverage.toml
@@ -567,7 +567,7 @@ slug = "invalid_field"
 trigger_kind = "parse_authority"
 trigger_fixture = "tests/data/error_fixtures/e106_authority_field_too_short.bin"
 description = "Authority record's 100 data-field directory length set to '0001' (1 byte; below the 2-byte indicator minimum)."
-expected_context = ["record_index", "byte_offset"]
+expected_context = ["record_index", "byte_offset", "field_tag"]
 recovery_modes = ["strict"]
 wired = true
 


### PR DESCRIPTION
## Problem

The per-reader minimum-bytes guard (`B::validate_data_field_bytes` — authority's `< 2`, holdings' `< 3`) in `iso2709_skeleton.rs` ran *before* the field loop set `ctx.current_field_tag` and `ctx.stream_byte_offset`. Those assignments only executed on the post-guard parse path, so an `InvalidField` (E106) raised by the guard inherited stale positional state: `byte_offset` pointed at the directory entry (or a prior field) and `field_tag` was `None`.

Concretely, for the `e106_authority_field_too_short` fixture (authority `100` data field below the 2-byte minimum), the directory entry sits at file byte 60 while the field's data starts at byte 143 — the error reported `byte_offset = 60` and `field_tag = None`, so a consumer's offset landed inside the directory, not the field.

## Fix

- Move the `ctx.current_field_tag` / `ctx.stream_byte_offset` assignments ahead of the guard invocation, so the guard's error carries the field's data-area `byte_offset` and the correct `field_tag`.
- Clear `ctx.current_field_tag` on the guard's error branch so field context doesn't leak into the next iteration (mirrors the existing post-parse reset).

## Tests

- Expanded the `e106_authority_field_too_short` coverage case to assert `field_tag`.
- Added a focused regression test in `authority_reader` that pins the exact `byte_offset` (the field's data-area start, `base_address`) and `field_tag` (`"100"`). The error-coverage manifest is presence-only, which the pre-fix stale-but-non-null offset would have passed — confirmed the new test fails against the unpatched skeleton and passes with the fix.

`.cargo/check.sh` green (565 Rust tests + doc tests + clippy + ruff + mkdocs).

Bead: bd-0x73.21.11