### PR TITLE
Apply NIT fixes from v0.8.1 milestone-wide quality review

### DIFF
--- a/benches/error_handling_benchmarks.rs
+++ b/benches/error_handling_benchmarks.rs
@@ -22,12 +22,10 @@
 //!   the cap.note bookkeeping. Fixture is pre-mutated in setup so
 //!   the per-iteration work is just parsing.
 //!
-//! Recovery-mode cost (lenient / permissive over a stream with
-//! detected errors) is excluded from this file because the
-//! recovered-error cap aborts iteration before producing a stable
-//! signal under the malformation density needed to exercise it; that
-//! scenario is added once `with_max_errors` is configurable per
-//! benchmark and the per-record-diagnostic surface is in place.
+//! The `parse_10k_bad_indicators_lenient` scenario disables the
+//! recovered-error cap (`with_max_errors(0)`) so iteration runs to
+//! completion over the fully-malformed stream and produces a stable
+//! signal for lenient recovery cost.
 //!
 //! Run with `cargo bench --bench error_handling_benchmarks` for local
 //! profiling. Codspeed exercises the same scenarios in CI for general

--- a/mrrc/_mrrc.pyi
+++ b/mrrc/_mrrc.pyi
@@ -190,7 +190,7 @@ class Record:
     def __str__(self) -> str: ...
     def __eq__(self, other: object) -> bool: ...
     @property
-    def errors(self) -> list[Any]:
+    def errors(self) -> list[Exception]:
         """Non-fatal errors accumulated while parsing this record.
 
         Always empty in ``recovery_mode="strict"``. Populated in
@@ -308,7 +308,7 @@ class AuthorityRecord:
     @property
     def leader(self) -> Leader: ...
     @property
-    def errors(self) -> list[Any]:
+    def errors(self) -> list[Exception]:
         """Non-fatal errors accumulated while parsing this record.
         See :attr:`Record.errors`.
         """
@@ -352,7 +352,7 @@ class HoldingsRecord:
     @property
     def leader(self) -> Leader: ...
     @property
-    def errors(self) -> list[Any]:
+    def errors(self) -> list[Exception]:
         """Non-fatal errors accumulated while parsing this record.
         See :attr:`Record.errors`.
         """

--- a/src-python/src/readers.rs
+++ b/src-python/src/readers.rs
@@ -116,9 +116,12 @@ impl PyMARCReader {
     ///   `recovery_mode`.
     /// * `max_errors` - Optional cap on accumulated recovered errors
     ///   per stream in lenient/permissive mode. `None` (default)
-    ///   preserves the Rust core's `DEFAULT_MAX_ERRORS` (10_000).
-    ///   `0` disables the cap entirely. Any other value trips
-    ///   `FatalReaderError` (E099) once the cap is exceeded.
+    ///   disables the wrapper-level cap; `0` also disables it (no-cap
+    ///   sentinel). `Some(N)` trips `FatalReaderError` (E099) once more
+    ///   than N recovered errors accumulate across the stream. (Each
+    ///   record is parsed by an ephemeral reader, so the Rust core's
+    ///   per-record `DEFAULT_MAX_ERRORS` never accumulates across the
+    ///   stream — this wrapper cap is the only cross-stream limit.)
     #[new]
     #[pyo3(signature = (
         source,

--- a/tests/error_coverage.toml
+++ b/tests/error_coverage.toml
@@ -48,10 +48,10 @@
 #                      "recovery_cap"   — drive lenient mode past max_errors
 #                      "accessor"       — call a Record accessor on a parsed record
 #                      "writer"         — construct a record and attempt to write it
-#                    The current harness implements parse_iso2709,
-#                    parse_marcxml, and parse_marcjson; other kinds skip
-#                    with a manifest-driven reason until the matching
-#                    harness mechanism lands.
+#                    The authoritative list of implemented trigger_kinds
+#                    is the module docstring in tests/error_coverage.rs;
+#                    kinds not yet implemented there skip with a
+#                    manifest-driven reason until their harness lands.
 #   trigger_fixture  path to fixture bytes (parse_iso2709) or text
 #                    (parse_marcxml / parse_marcjson) that should fire
 #                    `code`. Required for parse_* kinds; optional for
@@ -461,6 +461,9 @@ slug = "directory_invalid"
 trigger_kind = "parse_iso2709"
 trigger_fixture = "tests/data/error_fixtures/e101_non_ascii_tag.bin"
 description = "Directory entry 1 tag's first byte replaced with 0xCC (non-ASCII)."
+# field_tag omitted: the tag bytes are themselves the malformation, so the
+# parser does not set current_field_tag on this path (unlike the E106
+# data-field guard, where the tag is known).
 expected_context = ["record_index", "byte_offset", "record_byte_offset"]
 recovery_modes = ["strict"]
 wired = true

--- a/tests/error_coverage.toml
+++ b/tests/error_coverage.toml
@@ -48,10 +48,12 @@
 #                      "recovery_cap"   — drive lenient mode past max_errors
 #                      "accessor"       — call a Record accessor on a parsed record
 #                      "writer"         — construct a record and attempt to write it
-#                    The authoritative list of implemented trigger_kinds
-#                    is the module docstring in tests/error_coverage.rs;
-#                    kinds not yet implemented there skip with a
-#                    manifest-driven reason until their harness lands.
+#                    The authoritative list of trigger_kinds the Rust
+#                    harness exercises is the module docstring in
+#                    tests/error_coverage.rs. A kind that harness can't
+#                    drive (e.g. parse_marcjson — no Rust str-to-Record
+#                    entry point; covered in the Python harness instead)
+#                    skips with a manifest-driven reason.
 #   trigger_fixture  path to fixture bytes (parse_iso2709) or text
 #                    (parse_marcxml / parse_marcjson) that should fire
 #                    `code`. Required for parse_* kinds; optional for

--- a/tests/fuzz_regressions.rs
+++ b/tests/fuzz_regressions.rs
@@ -20,7 +20,7 @@ fn fixtures_dir(target: &str) -> PathBuf {
 }
 
 /// Walks every fixture under the given target directory and yields its
-/// bytes. Returns the empty iterator if the directory does not exist
+/// bytes. Returns an empty Vec if the directory does not exist
 /// (no regressions filed yet for this target).
 fn fixtures(target: &str) -> Vec<(PathBuf, Vec<u8>)> {
     let dir = fixtures_dir(target);

--- a/tests/validation_level_matrix.rs
+++ b/tests/validation_level_matrix.rs
@@ -64,13 +64,10 @@ fn drain(
     }
 }
 
-/// Run the matrix against one fixture, asserting `error_code` fires in
-/// every cell of the 2×3 grid. Used for errors that are unconditional —
-/// i.e., not gated on `validation_level` and not recoverable in
-/// `lenient`/`permissive`. Leader/structural errors that prevent the
-/// parser from establishing a record boundary (E001, E002 structural,
-/// E003, E004) are fatal in this sense: the recovery cap has nothing
-/// to absorb because there's no valid boundary to skip past.
+/// Run the matrix against one fixture for an error that fires only at
+/// `RecoveryMode::Strict`. `lenient`/`permissive` must NOT surface it —
+/// the recovery cap absorbs it — so those cells assert clean iteration.
+/// Independent of `validation_level`: both levels behave identically.
 fn run_strict_only_matrix(fixture_name: &str, error_code: &'static str) {
     let bytes = fixture_bytes(fixture_name);
     for validation in [ValidationLevel::Structural, ValidationLevel::StrictMarc] {
@@ -97,6 +94,13 @@ fn run_strict_only_matrix(fixture_name: &str, error_code: &'static str) {
     }
 }
 
+/// Run the matrix against one fixture, asserting `error_code` fires in
+/// every cell of the 2×3 grid. Used for errors that are unconditional —
+/// i.e., not gated on `validation_level` and not recoverable in
+/// `lenient`/`permissive`. Leader/structural errors that prevent the
+/// parser from establishing a record boundary (E001, E002 structural,
+/// E003, E004) are fatal in this sense: the recovery cap has nothing
+/// to absorb because there's no valid boundary to skip past.
 fn run_fatal_matrix(fixture_name: &str, error_code: &'static str) {
     let bytes = fixture_bytes(fixture_name);
     for validation in [ValidationLevel::Structural, ValidationLevel::StrictMarc] {


### PR DESCRIPTION
Comment/doc-only NIT fixes surfaced by the milestone-wide quality review (9lui / #204). No behavior change; `.cargo/check.sh` green (565 tests + doc tests + clippy + ruff + mkdocs).

- **`src-python/src/readers.rs`** — the `max_errors` constructor docstring claimed `None` "preserves DEFAULT_MAX_ERRORS (10_000)". It actually *disables* the cross-stream cap (each record is parsed by an ephemeral reader, so the core per-record cap never accumulates). Corrected to match the struct-field doc, wrapper, `.pyi`, and CHANGELOG — a comment that lied.
- **`tests/validation_level_matrix.rs`** — the doc block describing the fatal 2×3 matrix sat on `run_strict_only_matrix` (whose lenient/permissive cells assert *no* fire). Moved it to `run_fatal_matrix`; gave `run_strict_only_matrix` an accurate doc.
- **`tests/error_coverage.toml`** — header no longer re-enumerates implemented `trigger_kind`s (stale; harness now does 8+) — points at the harness module docstring as the authoritative list. Added a note on `e101_non_ascii_tag` explaining why `field_tag` is omitted.
- **`benches/error_handling_benchmarks.rs`** — dropped the stale "recovery-mode cost is excluded… added once `with_max_errors` is configurable" paragraph; that scenario now exists.
- **`tests/fuzz_regressions.rs`** — `fixtures()` doc said "empty iterator"; it returns a `Vec`.
- **`mrrc/_mrrc.pyi`** — `errors` property typed `list[Any]` → `list[Exception]`.

Two non-blocking FIX items from the review were filed as separate beads (not in this PR): bd-rk8f (fuzz code-list drift guard) and bd-q0zi (reader keyword-only signature mismatch, under the docs epic bd-c7ok).

Bead: bd-v081-milestone-quality-review-9lui