### PR TITLE
Cross-link the Query DSL guide from three guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invalid directory entry, not a malformed data field. The
   `InvalidField` shape is preserved for the data-field call sites
   that share these helpers.
+- The performance-tuning, migration-from-pymarc, and
+  working-with-large-files guides now point to the Query DSL guide where
+  field filtering is discussed, so readers discover the
+  indicator/range/pattern/subfield matching path. Thanks to @acdha
+  (#234).
 
 ### Fixed
 

--- a/docs/guides/migration-from-pymarc.md
+++ b/docs/guides/migration-from-pymarc.md
@@ -200,6 +200,11 @@ record.as_json()                       # pymarc MARC-in-JSON string
 record.as_dict()                       # pymarc-compatible dict
 ```
 
+For field selection beyond `get_fields(*tags)` — matching on indicators, tag
+ranges, subfield presence, or a regex over subfield values — see the
+[Query DSL guide](query-dsl.md). It's an mrrc extension with no pymarc
+equivalent.
+
 ### Control Fields (Unified with Field)
 ```python
 # Control fields are now Field instances (matching pymarc)

--- a/docs/guides/performance-tuning.md
+++ b/docs/guides/performance-tuning.md
@@ -87,6 +87,12 @@ with ThreadPoolExecutor(max_workers=optimal_workers) as executor:
 
 For 1 million records with 4 threads: ~4 GB peak (same as single-threaded).
 
+**Filter in Rust with the Query DSL.** When you only need a subset of a
+record's fields, the [Query DSL](query-dsl.md) lets you express the match
+(by indicator, tag range, subfield presence, or regex) so the filtering
+runs in Rust and only the matching fields cross into Python — instead of
+materializing every field as a Python object and filtering in a loop.
+
 ## Troubleshooting
 
 ### No Speedup with Multiple Threads

--- a/docs/guides/working-with-large-files.md
+++ b/docs/guides/working-with-large-files.md
@@ -63,6 +63,11 @@ def filter_books(path):
 books = list(filter_books("file.mrc"))
 ```
 
+When the per-record work is field selection — pulling just the fields that
+match some criteria — express it with the [Query DSL](query-dsl.md) so the
+filtering stays in Rust during the streaming pass instead of walking every
+field in Python.
+
 ### Rust
 
 ```rust


### PR DESCRIPTION
The performance-tuning, migration-from-pymarc, and working-with-large-files guides never mentioned the Query DSL — even though it's one of the best ways to filter fields without crossing the Rust/Python boundary and materializing every field as a Python object. Adds a short, contextual pointer to `docs/guides/query-dsl.md` from each, placed where the reader is already thinking about field access or performance:

- **performance-tuning** — in "Memory Overhead": filter in Rust so only matching fields cross into Python.
- **migration-from-pymarc** — right after the `get_fields` coverage: the DSL goes beyond `get_fields(*tags)` for indicator/range/pattern/subfield matching, with no pymarc equivalent.
- **working-with-large-files** — in the streaming/filter discussion: keep field selection in Rust during the streaming pass.

mkdocs builds clean with no broken-link warnings; CHANGELOG `[Unreleased]` credits @acdha.

Reported by @acdha in #225.

Closes #234

Bead: bd-pebk