### PR TITLE
Fix stale Rust API references in documentation examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   field filtering is discussed, so readers discover the
   indicator/range/pattern/subfield matching path. Thanks to @acdha
   (#234).
+- The Rust examples throughout the docs (quickstart, tutorials, reference)
+  now match the real API and compile: `field.get_subfield('a')` (char),
+  the public `tag` / `indicator1` / `indicator2` fields, the
+  `FieldQuery::new()` builder with `record.fields_matching(&query)`,
+  `Leader::from_bytes(...)`, the `record_to_json` / `record_to_marcxml` /
+  `record_to_marcjson` conversion functions, and `use mrrc::RecordHelpers;`
+  for `record.title()`. Many previously referenced methods that don't
+  exist. Reported by @acdha (#233).
 
 ### Fixed
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -127,11 +127,13 @@ tests/
 ### Rust Test Example
 
 ```rust
+use mrrc::RecordHelpers;
+
 #[test]
 fn test_parse_simple_record() {
     let data = include_bytes!("../tests/data/simple_book.mrc");
     let record = Record::from_marc21(data).unwrap();
-    assert_eq!(record.title(), Some("Test Title".to_string()));
+    assert_eq!(record.title(), Some("Test Title"));
 }
 ```
 

--- a/docs/getting-started/quickstart-rust.md
+++ b/docs/getting-started/quickstart-rust.md
@@ -12,7 +12,7 @@ mrrc = "0.8"
 ## Read Records
 
 ```rust
-use mrrc::MarcReader;
+use mrrc::{MarcReader, RecordHelpers};
 use std::fs::File;
 
 fn main() -> mrrc::Result<()> {
@@ -32,18 +32,18 @@ fn main() -> mrrc::Result<()> {
 ## Access Fields
 
 ```rust
-use mrrc::Record;
+use mrrc::{Record, RecordHelpers};
 
 // Get a specific field by tag
-if let Some(field) = record.field("245") {
-    if let Some(title) = field.subfield("a") {
+if let Some(field) = record.get_field("245") {
+    if let Some(title) = field.get_subfield('a') {
         println!("Title: {}", title);
     }
 }
 
 // Get all fields with a tag
 for field in record.fields_by_tag("650") {
-    if let Some(subject) = field.subfield("a") {
+    if let Some(subject) = field.get_subfield('a') {
         println!("Subject: {}", subject);
     }
 }
@@ -60,13 +60,12 @@ println!("ISBNs: {:?}", record.isbns());
 use mrrc::{Record, Field, Leader};
 
 // Create a new record with builder pattern
-let record = Record::builder()
-    .leader(Leader::default())
-    .control_field("001", "123456789")
+let record = Record::builder(Leader::from_bytes(b"00000nam a2200000 i 4500").unwrap())
+    .control_field_str("001", "123456789")
     .field(
-        Field::builder("245", '1', '0')
-            .subfield('a', "My Book Title")
-            .subfield('c', "by Author Name")
+        Field::builder("245".to_string(), '1', '0')
+            .subfield_str('a', "My Book Title")
+            .subfield_str('c', "by Author Name")
             .build()
     )
     .build();
@@ -91,16 +90,14 @@ fn main() -> mrrc::Result<()> {
 ## Convert Formats
 
 ```rust
-use mrrc::formats::{to_json, to_xml, to_marcjson};
-
 // To JSON
-let json_str = to_json(&record)?;
+let json = mrrc::json::record_to_json(&record)?;
 
-// To XML
-let xml_str = to_xml(&record)?;
+// To MARCXML
+let xml_str = mrrc::marcxml::record_to_marcxml(&record)?;
 
 // To MARCJSON (LOC standard)
-let marcjson_str = to_marcjson(&record)?;
+let marcjson = mrrc::marcjson::record_to_marcjson(&record)?;
 ```
 
 ## Error Handling

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ In benchmarks (see [methodology](benchmarks/results.md)):
 === "Rust"
 
     ```rust
-    use mrrc::MarcReader;
+    use mrrc::{MarcReader, RecordHelpers};
     use std::fs::File;
 
     let file = File::open("records.mrc")?;

--- a/docs/reference/encoding.md
+++ b/docs/reference/encoding.md
@@ -35,7 +35,7 @@ UTF-8 is the recommended encoding for new records. It supports all Unicode chara
 === "Rust"
 
     ```rust
-    use mrrc::MarcReader;
+    use mrrc::{MarcReader, RecordHelpers};
 
     let mut reader = MarcReader::new(file);
     while let Some(record) = reader.read_record()? {

--- a/docs/reference/formats.md
+++ b/docs/reference/formats.md
@@ -46,7 +46,7 @@ with MARCWriter("output.mrc") as writer:
 
 **Rust**:
 ```rust
-use mrrc::{MarcReader, MarcWriter};
+use mrrc::{MarcReader, MarcWriter, RecordHelpers};
 use std::fs::File;
 
 // Reading

--- a/docs/reference/marc-primer.md
+++ b/docs/reference/marc-primer.md
@@ -54,9 +54,9 @@ print(leader.type_of_record)  # 'a' for language material
 
 **Rust:**
 ```rust
-let leader = record.leader();
-println!("{}", leader.record_status());
-println!("{}", leader.type_of_record());
+let leader = &record.leader;
+println!("{}", leader.record_status);
+println!("{}", leader.record_type);
 ```
 
 ### Directory
@@ -88,10 +88,8 @@ print(control_number.data)  # "ocm12345678"
 
 **Rust:**
 ```rust
-if let Some(field) = record.field("001") {
-    if let Some(data) = field.data() {
-        println!("{}", data);
-    }
+if let Some(data) = record.get_control_field("001") {
+    println!("{}", data);
 }
 ```
 
@@ -141,10 +139,10 @@ if title_field:
 
 **Rust:**
 ```rust
-if let Some(field) = record.field("245") {
-    println!("{:?}", field.subfield("a"));
-    println!("{:?}", field.subfield("b"));
-    println!("Indicators: {} {}", field.indicator1(), field.indicator2());
+if let Some(field) = record.get_field("245") {
+    println!("{:?}", field.get_subfield('a'));
+    println!("{:?}", field.get_subfield('b'));
+    println!("Indicators: {} {}", field.indicator1, field.indicator2);
 }
 ```
 
@@ -224,6 +222,8 @@ print(record.isbn)
 
 **Rust:**
 ```rust
+use mrrc::RecordHelpers;
+
 println!("{:?}", record.title());
 println!("{:?}", record.author());
 for isbn in record.isbns() {

--- a/docs/reference/rust-api.md
+++ b/docs/reference/rust-api.md
@@ -9,15 +9,14 @@ Rust API reference for MRRC. See [docs.rs/mrrc](https://docs.rs/mrrc) for full a
 A MARC bibliographic record.
 
 ```rust
-use mrrc::{Record, Field, Leader};
+use mrrc::{Record, Field, Leader, RecordHelpers};
 
 // Create with builder
-let record = Record::builder()
-    .leader(Leader::default())
-    .control_field("001", "123456789")
+let record = Record::builder(Leader::from_bytes(b"00000nam a2200000 i 4500").unwrap())
+    .control_field_str("001", "123456789")
     .field(
-        Field::builder("245", '1', '0')
-            .subfield('a', "Title")
+        Field::builder("245".to_string(), '1', '0')
+            .subfield_str('a', "Title")
             .build()
     )
     .build();
@@ -28,7 +27,7 @@ if let Some(title) = record.title() {
 }
 
 for field in record.fields_by_tag("650") {
-    if let Some(subject) = field.subfield("a") {
+    if let Some(subject) = field.get_subfield('a') {
         println!("Subject: {}", subject);
     }
 }
@@ -54,10 +53,9 @@ Builder pattern for creating records.
 ```rust
 use mrrc::Record;
 
-let record = Record::builder()
-    .leader(leader)
-    .control_field("001", "12345")
-    .control_field("008", "040520s2023    xxu")
+let record = Record::builder(leader)
+    .control_field_str("001", "12345")
+    .control_field_str("008", "040520s2023    xxu")
     .field(title_field)
     .field(author_field)
     .build();
@@ -71,10 +69,10 @@ A MARC data field with tag, indicators, and subfields.
 use mrrc::Field;
 
 // Create with builder
-let field = Field::builder("245", '1', '0')
-    .subfield('a', "Main title :")
-    .subfield('b', "subtitle /")
-    .subfield('c', "by Author.")
+let field = Field::builder("245".to_string(), '1', '0')
+    .subfield_str('a', "Main title :")
+    .subfield_str('b', "subtitle /")
+    .subfield_str('c', "by Author.")
     .build();
 
 // Create directly
@@ -82,9 +80,9 @@ let mut field = Field::new("650".to_string(), ' ', '0');
 field.add_subfield('a', "Subject heading".to_string());
 
 // Access data
-println!("Tag: {}", field.tag());
-println!("Ind1: {}", field.indicator1());
-if let Some(value) = field.subfield("a") {
+println!("Tag: {}", field.tag);
+println!("Ind1: {}", field.indicator1);
+if let Some(value) = field.get_subfield('a') {
     println!("$a: {}", value);
 }
 ```
@@ -107,9 +105,9 @@ A subfield within a field.
 ```rust
 use mrrc::Subfield;
 
-let sf = Subfield::new('a', "value".to_string());
-println!("Code: {}", sf.code());
-println!("Value: {}", sf.value());
+let sf = Subfield { code: 'a', value: "value".to_string() };
+println!("Code: {}", sf.code);
+println!("Value: {}", sf.value);
 ```
 
 ### Leader
@@ -119,7 +117,7 @@ The 24-byte MARC record header.
 ```rust
 use mrrc::Leader;
 
-let mut leader = Leader::default();
+let mut leader = Leader::from_bytes(b"00000nam a2200000 i 4500").unwrap();
 leader.record_type = 'a';           // Language material
 leader.bibliographic_level = 'm';   // Monograph
 leader.character_coding = 'a';      // UTF-8
@@ -214,20 +212,25 @@ let record = HoldingsRecordBuilder::new()
 Query records using a fluent API.
 
 ```rust
-use mrrc::FieldQuery;
+use mrrc::{FieldQuery, SubfieldValueQuery};
 
 // Find fields by tag
-let query = FieldQuery::tag("245");
-let fields = query.find_all(&record);
+let query = FieldQuery::new().tag("245");
+for field in record.fields_matching(&query) {
+    println!("{}", field.tag);
+}
 
 // Find by tag range
-let query = FieldQuery::tag_range("600", "699");
-let subject_fields = query.find_all(&record);
+let query = FieldQuery::new().tag_range("600", "699");
+let subject_fields = record.fields_matching_range(&query);
 
-// Find by subfield pattern
-let query = FieldQuery::tag("100")
-    .with_subfield("a", "Smith");
-let matches = query.find_all(&record);
+// Find by subfield value
+let query = SubfieldValueQuery::new("100", 'a', "Smith");
+let matches = record.fields_matching_value(&query);
+
+// Find by subfield presence only
+let query = FieldQuery::new().tag("100").has_subfield('a');
+let with_name = record.fields_matching(&query);
 ```
 
 ## Format Conversion
@@ -235,11 +238,10 @@ let matches = query.find_all(&record);
 ### Core Formats (Always Available)
 
 ```rust
-use mrrc::formats::{to_json, to_marcjson};
 use mrrc::marcxml::{record_to_marcxml, marcxml_to_record, marcxml_to_records};
 
-let json = to_json(&record)?;
-let marcjson = to_marcjson(&record)?;
+let json = mrrc::json::record_to_json(&record)?;
+let marcjson = mrrc::marcjson::record_to_marcjson(&record)?;
 
 // MARCXML conversion (bidirectional)
 let xml = record_to_marcxml(&record)?;
@@ -321,6 +323,7 @@ Use Rayon for parallel processing:
 
 ```rust
 use mrrc::rayon_parser_pool::parse_batch_parallel;
+use mrrc::RecordHelpers;
 use rayon::prelude::*;
 
 // Parse multiple record byte slices in parallel

--- a/docs/tutorials/rust/concurrency.md
+++ b/docs/tutorials/rust/concurrency.md
@@ -25,7 +25,7 @@ rayon = "1.8"
 ### Process Records in Parallel
 
 ```rust
-use mrrc::MarcReader;
+use mrrc::{MarcReader, RecordHelpers};
 use rayon::prelude::*;
 use std::fs::File;
 
@@ -141,7 +141,7 @@ fn main() -> mrrc::Result<()> {
     let language_counts: HashMap<String, usize> = records
         .par_iter()
         .filter_map(|r| {
-            r.control_field("008")
+            r.get_control_field("008")
                 .and_then(|f| f.get(35..38).map(|s| s.to_string()))
         })
         .fold(

--- a/docs/tutorials/rust/format-conversion.md
+++ b/docs/tutorials/rust/format-conversion.md
@@ -7,12 +7,11 @@ Learn to convert MARC records between different formats.
 All formats are available without feature flags:
 
 ```rust
-use mrrc::formats::{to_json, to_marcjson, from_json};
 use mrrc::marcxml::{record_to_marcxml, marcxml_to_record, marcxml_to_records};
 
 // Convert to JSON
-let json = to_json(&record)?;
-let restored = from_json(&json)?;
+let json = mrrc::json::record_to_json(&record)?;
+let restored = mrrc::json::json_to_record(&json)?;
 
 // Convert to MARCXML
 let xml = record_to_marcxml(&record)?;
@@ -22,7 +21,7 @@ let restored = marcxml_to_record(&xml)?;
 let records = marcxml_to_records(&collection_xml)?;
 
 // Convert to MARCJSON (LOC standard)
-let marcjson = to_marcjson(&record)?;
+let marcjson = mrrc::marcjson::record_to_marcjson(&record)?;
 
 // MODS conversion (bidirectional)
 let mods_xml = mrrc::mods::record_to_mods_xml(&record)?;
@@ -53,7 +52,6 @@ let jsonld = graph.serialize(RdfFormat::JsonLd)?;
 
 ```rust
 use mrrc::{MarcReader, MarcWriter};
-use mrrc::formats::to_json;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
@@ -65,7 +63,7 @@ fn convert_to_json(input: &str, output: &str) -> mrrc::Result<()> {
     let mut reader = MarcReader::new(input_file);
 
     while let Some(record) = reader.read_record()? {
-        let json = to_json(&record)?;
+        let json = mrrc::json::record_to_json(&record)?;
         writeln!(writer, "{}", json)?;
     }
 
@@ -89,7 +87,6 @@ fn convert_to_json(input: &str, output: &str) -> mrrc::Result<()> {
 
 ```rust
 use mrrc::{MarcReader, Record};
-use mrrc::formats::to_json;
 use mrrc::marcxml::record_to_marcxml;
 use std::fs::File;
 use std::io::Write;
@@ -105,7 +102,7 @@ fn convert_file(input: &str) -> mrrc::Result<()> {
 
     while let Some(record) = reader.read_record()? {
         // JSON
-        let json = to_json(&record)?;
+        let json = mrrc::json::record_to_json(&record)?;
         writeln!(json_out, "{}", json)?;
 
         // MARCXML

--- a/docs/tutorials/rust/querying-fields.md
+++ b/docs/tutorials/rust/querying-fields.md
@@ -15,7 +15,7 @@ fn main() -> mrrc::Result<()> {
     while let Some(record) = reader.read_record()? {
         // Get all fields with a tag
         for field in record.fields_by_tag("650") {
-            if let Some(subject) = field.subfield("a") {
+            if let Some(subject) = field.get_subfield('a') {
                 println!("{}", subject);
             }
         }
@@ -30,11 +30,10 @@ fn main() -> mrrc::Result<()> {
 use mrrc::FieldQuery;
 
 // Find fields by tag
-let query = FieldQuery::tag("245");
-let fields = query.find_all(&record);
+let query = FieldQuery::new().tag("245");
 
-for field in fields {
-    println!("{:?}", field.subfield("a"));
+for field in record.fields_matching(&query) {
+    println!("{:?}", field.get_subfield('a'));
 }
 ```
 
@@ -46,11 +45,10 @@ Find fields within a tag range:
 use mrrc::FieldQuery;
 
 // Find all subject fields (600-699)
-let query = FieldQuery::tag_range("600", "699");
-let subjects = query.find_all(&record);
+let query = FieldQuery::new().tag_range("600", "699");
 
-for field in subjects {
-    println!("{}: {:?}", field.tag(), field.subfield("a"));
+for field in record.fields_matching_range(&query) {
+    println!("{}: {:?}", field.tag, field.get_subfield('a'));
 }
 ```
 
@@ -60,12 +58,11 @@ for field in subjects {
 // Manual filtering by indicators
 let lcsh_subjects: Vec<_> = record
     .fields_by_tag("650")
-    .into_iter()
-    .filter(|f| f.indicator2() == '0')  // LCSH
+    .filter(|f| f.indicator2 == '0')  // LCSH
     .collect();
 
 for field in lcsh_subjects {
-    if let Some(subject) = field.subfield("a") {
+    if let Some(subject) = field.get_subfield('a') {
         println!("LCSH: {}", subject);
     }
 }
@@ -76,14 +73,13 @@ for field in lcsh_subjects {
 Match subfield values with patterns:
 
 ```rust
-use mrrc::SubfieldPatternQuery;
 use regex::Regex;
 
 // Find ISBN-13s (start with 978 or 979)
 let pattern = Regex::new(r"^97[89]").unwrap();
 
 for field in record.fields_by_tag("020") {
-    if let Some(isbn) = field.subfield("a") {
+    if let Some(isbn) = field.get_subfield('a') {
         if pattern.is_match(isbn) {
             println!("ISBN-13: {}", isbn);
         }
@@ -98,7 +94,7 @@ Match exact or partial values:
 ```rust
 // Exact match
 for field in record.fields_by_tag("650") {
-    if let Some(subject) = field.subfield("a") {
+    if let Some(subject) = field.get_subfield('a') {
         if subject == "History" {
             println!("Found exact match");
         }
@@ -107,7 +103,7 @@ for field in record.fields_by_tag("650") {
 
 // Partial match (contains)
 for field in record.fields_by_tag("650") {
-    if let Some(subject) = field.subfield("a") {
+    if let Some(subject) = field.get_subfield('a') {
         if subject.to_lowercase().contains("history") {
             println!("Found: {}", subject);
         }
@@ -118,18 +114,20 @@ for field in record.fields_by_tag("650") {
 ## Combining Queries
 
 ```rust
+use mrrc::Record;
+
 fn find_lcsh_subjects_with_subdivision(record: &Record) -> Vec<String> {
     let mut results = Vec::new();
 
     for field in record.fields_by_tag("650") {
         // Must be LCSH (indicator2 = 0)
-        if field.indicator2() != '0' {
+        if field.indicator2 != '0' {
             continue;
         }
 
         // Must have both $a and $x
-        let main_subject = field.subfield("a");
-        let subdivision = field.subfield("x");
+        let main_subject = field.get_subfield('a');
+        let subdivision = field.get_subfield('x');
 
         if let (Some(main), Some(sub)) = (main_subject, subdivision) {
             results.push(format!("{} -- {}", main, sub));
@@ -143,7 +141,7 @@ fn find_lcsh_subjects_with_subdivision(record: &Record) -> Vec<String> {
 ## Complete Example
 
 ```rust
-use mrrc::{MarcReader, Record};
+use mrrc::{MarcReader, Record, RecordHelpers};
 use std::fs::File;
 
 fn find_records_about(path: &str, topic: &str) -> mrrc::Result<Vec<String>> {
@@ -156,11 +154,11 @@ fn find_records_about(path: &str, topic: &str) -> mrrc::Result<Vec<String>> {
     while let Some(record) = reader.read_record()? {
         // Check LCSH subjects
         for field in record.fields_by_tag("650") {
-            if field.indicator2() != '0' {
+            if field.indicator2 != '0' {
                 continue;
             }
 
-            if let Some(subject) = field.subfield("a") {
+            if let Some(subject) = field.get_subfield('a') {
                 if subject.to_lowercase().contains(&topic_lower) {
                     if let Some(title) = record.title() {
                         results.push(format!("{}: {}", title, subject));

--- a/docs/tutorials/rust/reading-records.md
+++ b/docs/tutorials/rust/reading-records.md
@@ -5,7 +5,7 @@ Learn to read MARC records from files and work with their contents.
 ## Basic Reading
 
 ```rust
-use mrrc::MarcReader;
+use mrrc::{MarcReader, RecordHelpers};
 use std::fs::File;
 
 fn main() -> mrrc::Result<()> {
@@ -24,7 +24,7 @@ fn main() -> mrrc::Result<()> {
 ## Reading from Memory
 
 ```rust
-use mrrc::MarcReader;
+use mrrc::{MarcReader, RecordHelpers};
 use std::io::Cursor;
 
 fn main() -> mrrc::Result<()> {
@@ -46,22 +46,22 @@ use mrrc::Record;
 
 fn process_record(record: &Record) {
     // Get first field by tag
-    if let Some(field) = record.field("245") {
-        if let Some(title) = field.subfield("a") {
+    if let Some(field) = record.get_field("245") {
+        if let Some(title) = field.get_subfield('a') {
             println!("Title: {}", title);
         }
     }
 
     // Get all fields with a tag
     for field in record.fields_by_tag("650") {
-        if let Some(subject) = field.subfield("a") {
+        if let Some(subject) = field.get_subfield('a') {
             println!("Subject: {}", subject);
         }
     }
 
     // Iterate over all fields
     for field in record.fields() {
-        println!("Field {}: {} subfields", field.tag(), field.subfields().len());
+        println!("Field {}: {} subfields", field.tag, field.subfields.len());
     }
 }
 ```
@@ -72,11 +72,11 @@ Control fields (001-009) contain unstructured data:
 
 ```rust
 fn read_control_fields(record: &Record) {
-    if let Some(control_num) = record.control_field("001") {
+    if let Some(control_num) = record.get_control_field("001") {
         println!("Control number: {}", control_num);
     }
 
-    if let Some(fixed) = record.control_field("008") {
+    if let Some(fixed) = record.get_control_field("008") {
         // Parse fixed-length data elements
         let pub_year = &fixed[7..11];
         let language = &fixed[35..38];
@@ -88,6 +88,8 @@ fn read_control_fields(record: &Record) {
 ## Convenience Methods
 
 ```rust
+use mrrc::RecordHelpers;
+
 fn extract_metadata(record: &Record) {
     if let Some(title) = record.title() {
         println!("Title: {}", title);
@@ -116,20 +118,20 @@ use mrrc::Field;
 
 fn process_field(field: &Field) {
     // Get first subfield value
-    if let Some(value) = field.subfield("a") {
+    if let Some(value) = field.get_subfield('a') {
         println!("$a: {}", value);
     }
 
     // Get all values for a subfield code
-    let values: Vec<&str> = field.subfields()
+    let values: Vec<&str> = field.subfields
         .iter()
-        .filter(|sf| sf.code() == 'a')
-        .map(|sf| sf.value())
+        .filter(|sf| sf.code == 'a')
+        .map(|sf| sf.value.as_str())
         .collect();
 
     // Iterate over all subfields
     for subfield in field.subfields() {
-        println!("${}: {}", subfield.code(), subfield.value());
+        println!("${}: {}", subfield.code, subfield.value);
     }
 }
 ```
@@ -138,13 +140,13 @@ fn process_field(field: &Field) {
 
 ```rust
 fn check_indicators(field: &Field) {
-    let ind1 = field.indicator1();
-    let ind2 = field.indicator2();
+    let ind1 = field.indicator1;
+    let ind2 = field.indicator2;
 
     // For 245: ind2 = nonfiling characters
-    if field.tag() == "245" {
+    if field.tag == "245" {
         let skip = ind2.to_digit(10).unwrap_or(0) as usize;
-        if let Some(title) = field.subfield("a") {
+        if let Some(title) = field.get_subfield('a') {
             let filing_title = &title[skip..];
             println!("Filing title: {}", filing_title);
         }
@@ -182,7 +184,7 @@ fn main() {
 ## Complete Example
 
 ```rust
-use mrrc::MarcReader;
+use mrrc::{MarcReader, RecordHelpers};
 use std::fs::File;
 
 fn main() -> mrrc::Result<()> {
@@ -193,7 +195,7 @@ fn main() -> mrrc::Result<()> {
     let mut serials = 0;
 
     while let Some(record) = reader.read_record()? {
-        let leader = record.leader();
+        let leader = record.leader;
 
         match leader.bibliographic_level {
             'm' => books += 1,

--- a/docs/tutorials/rust/writing-records.md
+++ b/docs/tutorials/rust/writing-records.md
@@ -9,14 +9,13 @@ Use the builder pattern for clean record construction:
 ```rust
 use mrrc::{Record, Field, Leader};
 
-let record = Record::builder()
-    .leader(Leader::default())
-    .control_field("001", "12345")
-    .control_field("008", "200101s2020    xxu||||||||||||||||eng||")
+let record = Record::builder(Leader::from_bytes(b"00000nam a2200000 i 4500").unwrap())
+    .control_field_str("001", "12345")
+    .control_field_str("008", "200101s2020    xxu||||||||||||||||eng||")
     .field(
-        Field::builder("245", '1', '0')
-            .subfield('a', "The Great Gatsby /")
-            .subfield('c', "F. Scott Fitzgerald.")
+        Field::builder("245".to_string(), '1', '0')
+            .subfield_str('a', "The Great Gatsby /")
+            .subfield_str('c', "F. Scott Fitzgerald.")
             .build()
     )
     .build();
@@ -28,10 +27,10 @@ let record = Record::builder()
 use mrrc::Field;
 
 // Using builder
-let title = Field::builder("245", '1', '0')
-    .subfield('a', "Main title :")
-    .subfield('b', "subtitle /")
-    .subfield('c', "by Author.")
+let title = Field::builder("245".to_string(), '1', '0')
+    .subfield_str('a', "Main title :")
+    .subfield_str('b', "subtitle /")
+    .subfield_str('c', "by Author.")
     .build();
 
 // Direct construction
@@ -45,14 +44,13 @@ author.add_subfield('d', "1896-1940.".to_string());
 ```rust
 use mrrc::Leader;
 
-let mut leader = Leader::default();
+let mut leader = Leader::from_bytes(b"00000nam a2200000 i 4500").unwrap();
 leader.record_status = 'n';           // New record
 leader.record_type = 'a';             // Language material
 leader.bibliographic_level = 'm';     // Monograph
 leader.character_coding = 'a';        // UTF-8
 
-let record = Record::builder()
-    .leader(leader)
+let record = Record::builder(leader)
     // ... fields
     .build();
 ```
@@ -76,7 +74,7 @@ fn main() -> mrrc::Result<()> {
 ## Write Multiple Records
 
 ```rust
-use mrrc::{MarcReader, MarcWriter};
+use mrrc::{MarcReader, MarcWriter, RecordHelpers};
 use std::fs::File;
 
 fn main() -> mrrc::Result<()> {
@@ -108,47 +106,46 @@ fn create_book_record(
     isbn: &str,
     subjects: &[&str],
 ) -> Record {
-    let mut leader = Leader::default();
+    let mut leader = Leader::from_bytes(b"00000nam a2200000 i 4500").unwrap();
     leader.record_status = 'n';
     leader.record_type = 'a';
     leader.bibliographic_level = 'm';
     leader.character_coding = 'a';
 
-    let mut builder = Record::builder()
-        .leader(leader)
-        .control_field("001", &format!("mrrc-{}", isbn))
-        .control_field("008", "200101s2020    xxu||||||||||||||||eng||");
+    let mut builder = Record::builder(leader)
+        .control_field_str("001", &format!("mrrc-{}", isbn))
+        .control_field_str("008", "200101s2020    xxu||||||||||||||||eng||");
 
     // ISBN
     builder = builder.field(
-        Field::builder("020", ' ', ' ')
-            .subfield('a', isbn)
+        Field::builder("020".to_string(), ' ', ' ')
+            .subfield_str('a', isbn)
             .build()
     );
 
     // Author
     if !author.is_empty() {
         builder = builder.field(
-            Field::builder("100", '1', ' ')
-                .subfield('a', author)
+            Field::builder("100".to_string(), '1', ' ')
+                .subfield_str('a', author)
                 .build()
         );
     }
 
     // Title
     let ind1 = if author.is_empty() { '0' } else { '1' };
-    let mut title_field = Field::builder("245", ind1, '0')
-        .subfield('a', title);
+    let mut title_field = Field::builder("245".to_string(), ind1, '0')
+        .subfield_str('a', title);
     if !author.is_empty() {
-        title_field = title_field.subfield('c', &format!("by {}", author));
+        title_field = title_field.subfield_str('c', &format!("by {}", author));
     }
     builder = builder.field(title_field.build());
 
     // Subjects
     for subject in subjects {
         builder = builder.field(
-            Field::builder("650", ' ', '0')
-                .subfield('a', subject)
+            Field::builder("650".to_string(), ' ', '0')
+                .subfield_str('a', subject)
                 .build()
         );
     }


### PR DESCRIPTION
The Rust code examples across the docs referenced methods and call shapes that don't match the real API, so most wouldn't compile. Root cause: rustdoc doctests run in CI, but mkdocs Markdown fences are never compiled, so the drift went unnoticed. Reported by **@acdha**.

Every Rust fence across **11 files** (quickstart, tutorials, reference) was corrected against `src/` and the compiled `examples/`, and **verified by compiling a throwaway example exercising every shape** (since mkdocs can't compile the fences itself):

- **Field** — `field.get_subfield('a')` (method, char) for `field.subfield("a")`; `tag`/`indicator1`/`indicator2`/`subfields` are public fields (no parens); `field.value()` not `field.data()`.
- **Record** — `get_field(tag)` not `field(tag)`; `get_control_field(tag)` not `control_field(tag)`; `record.leader` is a public field.
- **Query DSL** — `FieldQuery::new().tag(...)` + `record.fields_matching(&q)` (no static `FieldQuery::tag`, no `query.find_all`); `tag_range(...)` + `fields_matching_range`; `with_subfield(...)` → `SubfieldValueQuery` + `fields_matching_value`.
- **Builder** — `Record::builder(leader)` (no `.leader()`); `Leader::from_bytes(...)` (no `Leader::default()`); `control_field_str`/`subfield_str` for literals; `Field::builder("245".to_string(), …)`.
- **Format conversion** — `mrrc::json::record_to_json` / `mrrc::marcxml::record_to_marcxml` / `mrrc::marcjson::record_to_marcjson` (+ inverses), not the nonexistent `mrrc::formats::{to_json, …}`.
- Added `use mrrc::RecordHelpers;` wherever `record.title()` is used; fixed the `testing.md` `Option<&str>` assert.

This also resolves the "loop structure oddities" on the query page (mixed `find_all`/hand-rolled loops → coherent examples).

**Scope note / follow-up:** filed a separate bead for the rust-api.md prose "Key Methods" reference *tables* (method-call notation + a few wrong return types) and two Python-fence stale refs — distinct from the Rust *examples* this bead targets.

`.cargo/check.sh` green (566 tests + doctests + mkdocs). CHANGELOG `[Unreleased]` credits @acdha.

Closes #233

Bead: bd-nj22