### PR TITLE
Pin Windows CI runner to windows-2025

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025]
     steps:
       - uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
@@ -101,7 +101,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI Windows jobs are pinned to `windows-2025` (previously `windows-latest`)
+  ahead of GitHub's 2026-06-15 redirect of that label to a new image.
+
 ### Fixed
 
 - `Record.remove_field(field)` now removes exactly the given field instead of


### PR DESCRIPTION
GitHub redirects the `windows-latest` label to `windows-2025-vs2026` effective 2026-06-15 (per annotations on the v0.8.1 release run and other recent runs). This pins the Windows runner to an explicit image so the migration is deliberate rather than a surprise inside a build — particularly `python-release.yml`, which is on the release path.

- All five `windows-latest` references (build.yml, python-build.yml ×2, python-release.yml ×2) → `windows-2025`.
- Verified the pin preserves current behavior: the most recent Windows job (PR #249 wheel build) resolved `windows-latest` to image `windows-2025` (win25/20260525.149), so this changes nothing today.
- `matrix.os` otherwise feeds only job names and artifact names; upload/download pairs share the same expression, so artifact naming stays consistent within a run.

The Windows wheel build + test jobs on this PR's CI run are themselves the verification that the toolchain (Rust, Python, maturin) is green on the pinned image.

Bead: bd-ytyf
