### PR TITLE
Switch Python CodSpeed job to simulation mode; exclude parallel benchmarks

### DIFF
--- a/.github/workflows/benchmark-python.yml
+++ b/.github/workflows/benchmark-python.yml
@@ -88,7 +88,16 @@ jobs:
         with:
           # NOTE: Only enabled if CODSPEED_TOKEN is set as a repo secret
           token: ${{ secrets.CODSPEED_TOKEN }}
-          # Required for v4: use walltime mode for standard CI runners
-          mode: walltime
+          # Simulation mode measures instruction counts under Valgrind:
+          # deterministic on standard runners, unlike walltime, which cannot
+          # distinguish real regressions from runner-speed variance.
+          mode: simulation
+          # Parallel-throughput benchmarks are excluded: Valgrind serializes
+          # threads, so multi-threaded speedup cannot be measured under
+          # simulation. Measure parallel throughput with real walltime runs
+          # on controlled hardware instead.
           # Note: Don't use --benchmark-only here; CodSpeed handles benchmarks differently
-          run: pytest tests/python/ -m "benchmark and not slow" -v
+          run: >-
+            pytest tests/python/ -m "benchmark and not slow" -v
+            --ignore=tests/python/test_benchmark_parallel.py
+            --ignore=tests/python/test_benchmark_pipeline_parallel.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Python CodSpeed CI job now runs in simulation mode (previously walltime),
+  making PR performance-regression detection deterministic on hosted runners.
+  Parallel-throughput benchmarks are excluded from CodSpeed, since Valgrind
+  serializes threads; they remain runnable locally via pytest.
+
 - CI Windows jobs are pinned to `windows-2025` (previously `windows-latest`)
   ahead of GitHub's 2026-06-15 redirect of that label to a new image.
 


### PR DESCRIPTION
## Summary

The `codspeed` job in `benchmark-python.yml` ran in walltime mode on a standard hosted runner, where runner-speed variance is indistinguishable from real regressions — PR #249 reported 57 benches uniformly -20..-28% across different runners, which is runner noise, not a regression. The job was also the PR wall-clock long pole at ~10.7 min, since walltime runs many warmup/measurement rounds per bench.

This switches the job to `mode: simulation`, matching `benchmark-rust.yml` (3.4 min, no false regressions). Simulation measures instruction counts and cache behavior under Valgrind — deterministic, one pass per bench, sub-1% variance, so small real regressions become detectable instead of drowning in ±25% noise.

Valgrind serializes threads, so parallel-throughput benchmarks are meaningless under simulation. `test_benchmark_parallel.py` and `test_benchmark_pipeline_parallel.py` are excluded from the CodSpeed run (60 → 27 collected benches; everything remaining is single-threaded read/write/serialization/memory paths). Parallel throughput will be measured with real walltime runs on controlled hardware — a benchmarking-infrastructure assessment is in progress to define that.

Also removes the incorrect comment claiming walltime mode is "required for v4 on standard runners" — CodSpeed's docs show `mode: simulation` on plain `ubuntu-latest` as the standard setup.

## Notes

- Simulation and walltime are different metrics, so CodSpeed comparison history resets. After merge, trigger `workflow_dispatch` on main (or rely on the merge push) to seed the new baseline; the first PR after this one may show "no base" rather than a comparison.
- Verified locally: `pytest --collect-only` with the exclusions selects 27 benches; `.cargo/check.sh` green.

Bead: bd-ipu0

🤖 Generated with [Claude Code](https://claude.com/claude-code)