### PR TITLE
Exclude Rust parallel criterion bench from simulation-mode CodSpeed

### DIFF
--- a/.github/workflows/benchmark-rust.yml
+++ b/.github/workflows/benchmark-rust.yml
@@ -38,7 +38,13 @@ jobs:
           bins: cargo-codspeed
 
       - name: Build benchmarks
-        run: cargo codspeed build
+        # Allowlist the single-threaded criterion benches. parallel_benchmarks
+        # is excluded: Valgrind serializes threads under simulation mode, so
+        # rayon speedup cannot be measured there (its sequential baselines
+        # duplicate marc_benchmarks' read_* coverage). Run it locally with
+        # criterion for real walltime numbers. The remaining bench targets are
+        # print-only profiling harnesses that produce no CodSpeed signal.
+        run: cargo codspeed build --bench marc_benchmarks --bench error_handling_benchmarks
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Python CodSpeed CI job now runs in simulation mode (previously walltime),
   making PR performance-regression detection deterministic on hosted runners.
-  Parallel-throughput benchmarks are excluded from CodSpeed, since Valgrind
-  serializes threads; they remain runnable locally via pytest.
+  Parallel-throughput benchmarks (Python and Rust) are excluded from CodSpeed,
+  since Valgrind serializes threads; they remain runnable locally via pytest
+  and criterion.
 
 - CI Windows jobs are pinned to `windows-2025` (previously `windows-latest`)
   ahead of GitHub's 2026-06-15 redirect of that label to a new image.


### PR DESCRIPTION
## Summary

PR #251 excluded the Python parallel-throughput benchmark files from CodSpeed because Valgrind serializes threads under simulation mode, making measured "parallel" speedup meaningless. The Rust side had the same inconsistency: `benches/parallel_benchmarks.rs` was still collected by `cargo codspeed` in `benchmark-rust.yml`, reporting instruction counts for serialized rayon runs that measure nothing useful.

`cargo codspeed build` now allowlists the two single-threaded criterion benches: `--bench marc_benchmarks --bench error_handling_benchmarks`.

- No single-thread signal is lost: the sequential baselines in `parallel_benchmarks.rs` (`sequential_2x_1k`, etc.) duplicate `marc_benchmarks`' `read_1k_records`/`read_10k_records` coverage.
- `parallel_benchmarks.rs` stays intact for local criterion walltime runs; a documented parallel-throughput measurement procedure is tracked separately (bd-ieoe).
- The allowlist also stops building the four print-only profiling harnesses (`profiling_harness`, `detailed_profiling`, `rayon_profiling`, `rayon_file_io_profiling`), which produce no CodSpeed signal. Their removal is tracked separately (bd-1dbu).
- Extended the existing `[Unreleased]` CHANGELOG entry to note the exclusion now covers both Python and Rust.

## Verification

- `cargo bench --bench marc_benchmarks --bench error_handling_benchmarks --no-run` compiles both targets
- `.cargo/check.sh` green

Bead: bd-os4g

🤖 Generated with [Claude Code](https://claude.com/claude-code)