### PR TITLE
Consolidate CI workflows and slim PR build matrices

### DIFF
--- a/.cargo/check.sh
+++ b/.cargo/check.sh
@@ -8,6 +8,7 @@ set -e
 # Options
 MEMORY_CHECKS=false
 QUICK=false
+RELEASE=false
 
 # Parse command-line arguments
 while [[ $# -gt 0 ]]; do
@@ -18,6 +19,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --quick)
             QUICK=true
+            shift
+            ;;
+        --release)
+            RELEASE=true
             shift
             ;;
         *)
@@ -65,8 +70,15 @@ if [ "$QUICK" = false ]; then
     cargo audit
 
     echo ""
-    echo "=== Maturin Python extension build ==="
-    uv run maturin develop
+    if [ "$RELEASE" = true ]; then
+        echo "=== Maturin Python extension build (--release) ==="
+        # Release-mode codegen (inlining, optimizations) matches the wheels
+        # CI builds; use this to reproduce perf-sensitive regressions locally.
+        uv run maturin develop --release
+    else
+        echo "=== Maturin Python extension build ==="
+        uv run maturin develop
+    fi
 
     echo ""
     echo "=== Python tests (core functionality, excludes benchmarks) ==="

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,13 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-2025]
+  # Cross-OS compilation of the mrrc core crate is covered by the maturin
+  # matrix in python-build.yml (mrrc-python depends on mrrc). The only
+  # coverage unique to this workflow is compiling the examples/ tree, which
+  # runs once on ubuntu.
+  examples:
+    name: Build examples
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -42,9 +43,6 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Build library
-        run: cargo build --verbose --package mrrc
 
       - name: Build examples
         run: cargo build --examples --verbose

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -22,7 +22,116 @@ env:
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 
 jobs:
-  build-wheels:
+  # Slim matrix on pull requests: oldest + newest Python on Linux, plus a
+  # single sanity build on each alternate OS. 4 build + 4 test = 8 jobs.
+  build-wheels-pr:
+    if: github.event_name == 'pull_request'
+    name: Build wheels (PR) on ${{ matrix.os }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: "3.14"
+          - os: macos-latest
+            python-version: "3.12"
+          - os: windows-2025
+            python-version: "3.12"
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          manylinux: off
+          args: --release --out dist -i python${{ matrix.python-version }}
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
+          path: dist
+
+  test-wheels-pr:
+    if: github.event_name == 'pull_request'
+    name: Test wheels (PR) on ${{ matrix.os }} py${{ matrix.python-version }}
+    needs: build-wheels-pr
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: "3.14"
+          - os: macos-latest
+            python-version: "3.12"
+          - os: windows-2025
+            python-version: "3.12"
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
+          path: dist
+
+      - name: Install wheel and test dependencies
+        shell: bash
+        run: |
+          # Install the wheel together with the [test] extra from
+          # pyproject.toml so test deps stay in sync with the package.
+          WHEEL=$(ls dist/*.whl | head -1)
+          uv pip install --system "${WHEEL}[test]"
+
+      - name: Run pytest (core tests, excludes benchmarks)
+        run: |
+          pytest tests/python/ -m "not benchmark" -v
+        # Retry on macOS due to intermittent runner flakiness
+        # See: mrrc-vxmp - tests pass but job occasionally fails
+        if: runner.os != 'macOS'
+
+      - name: Run pytest with retry (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          max_attempts=3
+          attempt=1
+          while [ $attempt -le $max_attempts ]; do
+            echo "Attempt $attempt of $max_attempts"
+            if pytest tests/python/ -m "not benchmark" -v; then
+              echo "Tests passed on attempt $attempt"
+              exit 0
+            fi
+            echo "Attempt $attempt failed, retrying..."
+            attempt=$((attempt + 1))
+            sleep 5
+          done
+          echo "All $max_attempts attempts failed"
+          exit 1
+        shell: bash
+
+  # Full matrix on push to main: os {ubuntu, macos, windows} x
+  # python {3.10..3.14}. 15 build + 15 test = 30 jobs.
+  build-wheels-main:
+    if: github.event_name == 'push'
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -52,9 +161,10 @@ jobs:
           name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
           path: dist
 
-  test-wheels:
+  test-wheels-main:
+    if: github.event_name == 'push'
     name: Test wheels on ${{ matrix.os }}
-    needs: build-wheels
+    needs: build-wheels-main
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI Windows jobs are pinned to `windows-2025` (previously `windows-latest`)
   ahead of GitHub's 2026-06-15 redirect of that label to a new image.
 
+- Pull requests now build and test a slim wheel matrix (8 jobs) instead of the
+  full 30; the full `os × python` matrix still runs on push to main and on
+  release tags. The standalone Rust `build.yml` is reduced to a single
+  examples-compile job, since cross-OS core compilation is already covered by
+  the maturin wheel matrix. `.cargo/check.sh` gains a `--release` flag to build
+  the Python extension in release mode for perf-sensitive debugging.
+
 ### Fixed
 
 - `Record.remove_field(field)` now removes exactly the given field instead of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ Python bindings via PyO3/maturin.
 # Quick mode (skips docs, audit, maturin rebuild)
 .cargo/check.sh --quick
 
+# Release-mode maturin build (reproduces wheel codegen for perf debugging;
+# slower cold build). Default builds the extension in dev mode.
+.cargo/check.sh --release
+
 # Individual commands
 cargo test --lib --tests --package mrrc -q    # Rust tests
 cargo test --doc --package mrrc -q            # Doc tests


### PR DESCRIPTION
Tier A of the CI-hygiene umbrella: reduce redundant per-PR CI compute without losing release-time coverage.

## Changes

- **Slim the PR wheel matrix** (`python-build.yml`). The build/test jobs split into a slim PR pair (`build-wheels-pr` / `test-wheels-pr`) gated on `github.event_name == 'pull_request'` and a full pair (`build-wheels-main` / `test-wheels-main`) gated on `'push'`. PRs build oldest + newest Python on Linux plus one sanity build each on macOS and Windows; push to main keeps the full `os × python` matrix.
- **Shrink `build.yml`** to a single ubuntu examples-compile job. Cross-OS compilation of the `mrrc` core crate is already covered by the maturin wheel matrix (`mrrc-python` depends on `mrrc`), so the only coverage unique to `build.yml` is building the `examples/` tree. This keeps examples-compile coverage in CI while dropping 2 of 3 matrix jobs. (Full deletion is deferred until examples-compile is also added to `.cargo/check.sh`.)
- **Add a `--release` flag to `.cargo/check.sh`** that runs `maturin develop --release`, reproducing release-mode wheel codegen for perf-sensitive debugging. The default stays dev mode for fast iteration; documented in `CLAUDE.md` alongside `--quick`.

`python-release.yml` is unchanged — the full release matrix still runs on `v*` tags.

## Verification

- YAML parse of every edited workflow plus `python-release.yml` and `test.yml` via `uv run --with pyyaml python -c "import yaml; yaml.safe_load(...)"` — all parse; job/matrix counts confirmed programmatically.
- Job-count reasoning: a `pull_request` event fires `build-wheels-pr` (4) + `test-wheels-pr` (4) = **8** wheel jobs (the `-main` jobs are gated off), plus the single `build.yml` examples job. A `push` to main fires `build-wheels-main` (15) + `test-wheels-main` (15) = **30** wheel jobs (the `-pr` jobs gated off). A `v*` tag runs the unchanged full release matrix in `python-release.yml`.
- `.cargo/check.sh --release` run end-to-end from the worktree — confirmed the `maturin develop --release` path builds (`Finished \`release\` profile`) and the run ends with `✓ All checks passed`.
- CHANGELOG `[Unreleased] ### Changed` entry added; `scripts/lint-changelog.sh` passes (≤100-col wrap respected).

Beads: bd-uajr, bd-qbne, bd-ymcl

🤖 Generated with [Claude Code](https://claude.com/claude-code)