### PR TITLE
Ignore .beads/** in lint.yml so bead commits skip lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
       - 'mkdocs.yml'
       - 'LICENSE'
       - '.gitignore'
+      - '.beads/**'
   pull_request:
     branches: [main]
     paths-ignore:
@@ -17,6 +18,7 @@ on:
       - 'mkdocs.yml'
       - 'LICENSE'
       - '.gitignore'
+      - '.beads/**'
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Small follow-up that completes bd-no9e.1.

#257 added `.beads/**` to the `paths-ignore` of the four heavy workflows (test, benchmark-python, benchmark-rust, python-build), so bead-bookkeeping commits stopped triggering the test/benchmark/wheel matrix. But `lint.yml` was left on its existing filter, so a `.beads/**`-only commit still ran Rustfmt, Clippy, Documentation, Ruff, and Security Audit — and Clippy/Documentation compile the crate, so it isn't free. Observed live on the post-#258 `chore(beads)` commit, which triggered "Lint and Format" and nothing else.

This adds `.beads/**` to both the `push` and `pull_request` `paths-ignore` lists in `lint.yml`. `semver.yml` and `changelog.yml` already don't fire on bead-only commits (they use narrow `paths:` allow-lists), so lint was the last leak.

## Verification

`lint.yml` parses; both `paths-ignore` blocks now include `.beads/**`. After merge, a bead-only commit should trigger no CI workflows at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)