### PR TITLE
Upgrade pyo3 to 0.29 to resolve RUSTSEC-2026-0176

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated pyo3 to 0.29, resolving RUSTSEC-2026-0176 (out-of-bounds read in `nth`/
+  `nth_back` on `PyList`/`PyTuple` iterators in pyo3 ≤0.28).
 - Updated quick-xml to 0.40. MARCXML text and attribute decoding now applies XML 1.0
   end-of-line and attribute-value normalization explicitly (previously the XML 1.1 EOL
   set, which additionally folded NEL/LSEP — those are no longer normalized, matching

--- a/src-python/Cargo.toml
+++ b/src-python/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.2"
 edition = "2021"
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 mrrc = { path = ".." }
 serde_json = "1.0"
 # SmallVec for buffered reader: we own the bytes here to safely cross the GIL boundary.


### PR DESCRIPTION
RUSTSEC-2026-0176 (published 2026-06-11) flags an out-of-bounds read in `nth`/`nth_back` on `PyList`/`PyTuple` iterators in pyo3 ≤0.28.x. This bumps the pin in `src-python/Cargo.toml` from 0.28 to 0.29.

The upgrade is drop-in: no API changes were required anywhere in the bindings. Full `.cargo/check.sh` is green locally, including `cargo audit` (which was failing on every push since the advisory landed), the complete Rust and Python test suites, mypy, and stubtest.

Bead: bd-zjem

🤖 Generated with [Claude Code](https://claude.com/claude-code)