### PR TITLE
Buffer file-path readers with a 64 KiB BufReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- File-path readers now buffer their reads (64 KiB): Python `MARCReader(path)` (and the
+  authority/holdings readers) and Rust `from_path` previously issued two-plus `read(2)`
+  syscalls per record. Rust `from_path` constructors now return
+  `MarcReader<BufReader<File>>` instead of `MarcReader<File>`.
 - Updated pyo3 to 0.29, resolving RUSTSEC-2026-0176 (out-of-bounds read in `nth`/
   `nth_back` on `PyList`/`PyTuple` iterators in pyo3 ≤0.28).
 - Updated quick-xml to 0.40. MARCXML text and attribute decoding now applies XML 1.0

--- a/benches/marc_benchmarks.rs
+++ b/benches/marc_benchmarks.rs
@@ -48,6 +48,37 @@ fn benchmark_read_10k(c: &mut Criterion) {
     });
 }
 
+/// Benchmark reading 1,000 MARC records from a file path.
+///
+/// Unlike the cursor benchmarks above, this exercises the real file-I/O
+/// read loop, so it is sensitive to syscall count and buffering.
+fn benchmark_read_1k_from_path(c: &mut Criterion) {
+    c.bench_function("read_1k_records_from_path", |b| {
+        b.iter(|| {
+            let mut reader = MarcReader::from_path("tests/data/fixtures/1k_records.mrc").unwrap();
+            let mut count = 0;
+            while let Ok(Some(_record)) = reader.read_record() {
+                count += 1;
+            }
+            black_box(count)
+        });
+    });
+}
+
+/// Benchmark reading 10,000 MARC records from a file path.
+fn benchmark_read_10k_from_path(c: &mut Criterion) {
+    c.bench_function("read_10k_records_from_path", |b| {
+        b.iter(|| {
+            let mut reader = MarcReader::from_path("tests/data/fixtures/10k_records.mrc").unwrap();
+            let mut count = 0;
+            while let Ok(Some(_record)) = reader.read_record() {
+                count += 1;
+            }
+            black_box(count)
+        });
+    });
+}
+
 /// Benchmark reading 1,000 MARC records with field access.
 fn benchmark_read_with_field_access_1k(c: &mut Criterion) {
     let fixture = black_box(load_fixture("1k_records.mrc"));
@@ -178,6 +209,8 @@ criterion_group!(
     benches,
     benchmark_read_1k,
     benchmark_read_10k,
+    benchmark_read_1k_from_path,
+    benchmark_read_10k_from_path,
     benchmark_read_with_field_access_1k,
     benchmark_read_with_field_access_10k,
     benchmark_serialization_to_json_1k,

--- a/scripts/bench_read_throughput.py
+++ b/scripts/bench_read_throughput.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Measure wall-clock read throughput for MARC files via mrrc.
+
+Reads each file through MARCReader(path) — the RustFile backend — and
+reports records/second per repetition plus the median. Wall-clock numbers
+from a quiet machine are the payoff measurement for read-path changes;
+CI CodSpeed simulation tracks regressions but cannot back records/sec
+claims.
+
+Usage:
+    uv run python scripts/bench_read_throughput.py FILE [FILE ...] [--repeat N]
+
+The first repetition warms the OS page cache, so all repetitions measure
+the parse path rather than disk; pass --include-first to keep it anyway.
+"""
+
+import argparse
+import statistics
+import sys
+import time
+from pathlib import Path
+
+from mrrc import MARCReader
+
+
+def read_all(path):
+    """Drain one file; return (records, seconds)."""
+    start = time.perf_counter()
+    reader = MARCReader(str(path))
+    count = 0
+    while reader.read_record() is not None:
+        count += 1
+    elapsed = time.perf_counter() - start
+    return count, elapsed
+
+
+def bench_file(path, repeat, include_first):
+    runs = []
+    count = None
+    for i in range(repeat + (0 if include_first else 1)):
+        n, elapsed = read_all(path)
+        if count is None:
+            count = n
+            if not include_first:
+                continue  # discard the cache-warming repetition
+        elif n != count:
+            sys.exit(f"{path}: record count changed between runs ({count} vs {n})")
+        runs.append(n / elapsed)
+    return count, runs
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="+", type=Path, help=".mrc files to read")
+    parser.add_argument(
+        "--repeat", type=int, default=5, help="measured repetitions per file (default 5)"
+    )
+    parser.add_argument(
+        "--include-first",
+        action="store_true",
+        help="measure the first repetition instead of discarding it as cache warm-up",
+    )
+    args = parser.parse_args()
+
+    for path in args.files:
+        if not path.exists():
+            sys.exit(f"No such file: {path}")
+        count, runs = bench_file(path, args.repeat, args.include_first)
+        median = statistics.median(runs)
+        spread = (max(runs) - min(runs)) / median * 100
+        print(f"{path}: {count:,} records")
+        print(f"  runs (rec/s): {', '.join(f'{r:,.0f}' for r in runs)}")
+        print(f"  median: {median:,.0f} rec/s  (spread {spread:.1f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src-python/src/authority_readers.rs
+++ b/src-python/src/authority_readers.rs
@@ -4,17 +4,18 @@
 // Python file I/O. Only type-specific logic (AuthorityMarcReader, PyAuthorityRecord)
 // lives here.
 
+use crate::backend::FILE_READ_BUF_CAPACITY;
 use crate::reader_helpers;
 use crate::wrappers::PyAuthorityRecord;
 use mrrc::authority_reader::AuthorityMarcReader;
 use mrrc::recovery::{RecoveryMode, ValidationLevel};
 use pyo3::prelude::*;
 use std::fs::File;
-use std::io::Cursor;
+use std::io::{BufReader, Cursor};
 
 /// Internal enum for Authority reader backends
 enum AuthorityReaderBackend {
-    RustFile(AuthorityMarcReader<File>),
+    RustFile(AuthorityMarcReader<BufReader<File>>),
     CursorBackend(AuthorityMarcReader<Cursor<Vec<u8>>>),
     PythonFile(Py<PyAny>),
 }
@@ -57,6 +58,7 @@ impl PyAuthorityMARCReader {
 
         // Try file path (str or pathlib.Path)
         if let Some(file) = reader_helpers::try_open_as_path(source)? {
+            let file = BufReader::with_capacity(FILE_READ_BUF_CAPACITY, file);
             let reader = AuthorityMarcReader::new(file)
                 .with_recovery_mode(rec_mode)
                 .with_validation_level(val_level);

--- a/src-python/src/backend.rs
+++ b/src-python/src/backend.rs
@@ -9,7 +9,13 @@ use crate::parse_error::ParseError;
 use mrrc::RecoveryMode;
 use pyo3::prelude::*;
 use std::fs::File;
-use std::io::{Cursor, ErrorKind, Read};
+use std::io::{BufReader, Cursor, ErrorKind, Read};
+
+/// Buffer capacity for file-path backends. Matches the core readers'
+/// `from_path` buffering: the per-record read loop issues at least two
+/// small reads per record, and 64 KiB amortizes those to roughly one
+/// syscall per buffer fill.
+pub(crate) const FILE_READ_BUF_CAPACITY: usize = 64 * 1024;
 
 /// Unified backend interface for reading MARC records from different sources
 ///
@@ -31,9 +37,9 @@ pub struct ReaderBackend {
 
 #[derive(Debug)]
 enum BackendKind {
-    /// Direct file I/O via std::fs::File
+    /// Buffered file I/O via std::fs::File
     /// Input: str path or pathlib.Path
-    RustFile(File),
+    RustFile(BufReader<File>),
 
     /// In-memory reads from bytes via std::io::Cursor
     /// Input: bytes or bytearray
@@ -80,7 +86,10 @@ impl ReaderBackend {
         // 1. Try str path
         if let Ok(path_str) = source.extract::<String>() {
             return match File::open(&path_str) {
-                Ok(file) => Ok(BackendKind::RustFile(file)),
+                Ok(file) => Ok(BackendKind::RustFile(BufReader::with_capacity(
+                    FILE_READ_BUF_CAPACITY,
+                    file,
+                ))),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
                         "No such file or directory: '{}'",
@@ -107,7 +116,10 @@ impl ReaderBackend {
                 if let Ok(path_obj) = method.call0() {
                     if let Ok(path_str) = path_obj.extract::<String>() {
                         return match File::open(&path_str) {
-                            Ok(file) => Ok(BackendKind::RustFile(file)),
+                            Ok(file) => Ok(BackendKind::RustFile(BufReader::with_capacity(
+                                FILE_READ_BUF_CAPACITY,
+                                file,
+                            ))),
                             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                                 Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
                                     "No such file or directory: '{}'",
@@ -367,7 +379,7 @@ mod tests {
         // Test that backend can be instantiated
         let file = File::open("/dev/null").unwrap();
         let _backend = ReaderBackend {
-            kind: BackendKind::RustFile(file),
+            kind: BackendKind::RustFile(BufReader::with_capacity(FILE_READ_BUF_CAPACITY, file)),
             recovery_mode: RecoveryMode::Strict,
         };
 

--- a/src-python/src/holdings_readers.rs
+++ b/src-python/src/holdings_readers.rs
@@ -4,17 +4,18 @@
 // Python file I/O. Only type-specific logic (HoldingsMarcReader, PyHoldingsRecord)
 // lives here.
 
+use crate::backend::FILE_READ_BUF_CAPACITY;
 use crate::reader_helpers;
 use crate::wrappers::PyHoldingsRecord;
 use mrrc::holdings_reader::HoldingsMarcReader;
 use mrrc::recovery::{RecoveryMode, ValidationLevel};
 use pyo3::prelude::*;
 use std::fs::File;
-use std::io::Cursor;
+use std::io::{BufReader, Cursor};
 
 /// Internal enum for Holdings reader backends
 enum HoldingsReaderBackend {
-    RustFile(HoldingsMarcReader<File>),
+    RustFile(HoldingsMarcReader<BufReader<File>>),
     CursorBackend(HoldingsMarcReader<Cursor<Vec<u8>>>),
     PythonFile(Py<PyAny>),
 }
@@ -57,6 +58,7 @@ impl PyHoldingsMARCReader {
 
         // Try file path (str or pathlib.Path)
         if let Some(file) = reader_helpers::try_open_as_path(source)? {
+            let file = BufReader::with_capacity(FILE_READ_BUF_CAPACITY, file);
             let reader = HoldingsMarcReader::new(file)
                 .with_recovery_mode(rec_mode)
                 .with_validation_level(val_level);

--- a/src/authority_reader.rs
+++ b/src/authority_reader.rs
@@ -119,9 +119,11 @@ impl<R: Read> AuthorityMarcReader<R> {
     }
 }
 
-impl AuthorityMarcReader<std::fs::File> {
+impl AuthorityMarcReader<std::io::BufReader<std::fs::File>> {
     /// Open `path` for reading and create an [`AuthorityMarcReader`] whose
-    /// errors include the path as their `source_name`.
+    /// errors include the path as their `source_name`. Reads go through a
+    /// 64 KiB buffer, so the per-record read loop does not issue per-record
+    /// syscalls.
     ///
     /// # Errors
     ///
@@ -129,7 +131,8 @@ impl AuthorityMarcReader<std::fs::File> {
     pub fn from_path(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
         let path = path.as_ref();
         let file = std::fs::File::open(path)?;
-        Ok(Self::new(file).with_source(path.display().to_string()))
+        let reader = std::io::BufReader::with_capacity(crate::reader::FILE_READ_BUF_CAPACITY, file);
+        Ok(Self::new(reader).with_source(path.display().to_string()))
     }
 }
 

--- a/src/holdings_reader.rs
+++ b/src/holdings_reader.rs
@@ -117,9 +117,11 @@ impl<R: Read> HoldingsMarcReader<R> {
     }
 }
 
-impl HoldingsMarcReader<std::fs::File> {
+impl HoldingsMarcReader<std::io::BufReader<std::fs::File>> {
     /// Open `path` for reading and create a [`HoldingsMarcReader`] whose
-    /// errors include the path as their `source_name`.
+    /// errors include the path as their `source_name`. Reads go through a
+    /// 64 KiB buffer, so the per-record read loop does not issue per-record
+    /// syscalls.
     ///
     /// # Errors
     ///
@@ -127,7 +129,8 @@ impl HoldingsMarcReader<std::fs::File> {
     pub fn from_path(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
         let path = path.as_ref();
         let file = std::fs::File::open(path)?;
-        Ok(Self::new(file).with_source(path.display().to_string()))
+        let reader = std::io::BufReader::with_capacity(crate::reader::FILE_READ_BUF_CAPACITY, file);
+        Ok(Self::new(reader).with_source(path.display().to_string()))
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -42,6 +42,14 @@ use crate::record::{Field, Record};
 use crate::recovery::{self, RecoveryCap, RecoveryMode, ValidationLevel};
 use std::io::Read;
 
+/// Buffer capacity for readers opened from a filesystem path.
+///
+/// The per-record read loop issues at least two small reads per record
+/// (leader, then body); on an unbuffered `File` each is a syscall. 64 KiB
+/// amortizes that to roughly one syscall per buffer fill while staying
+/// small enough not to matter for memory.
+pub(crate) const FILE_READ_BUF_CAPACITY: usize = 64 * 1024;
+
 /// Reader for ISO 2709 binary MARC format.
 ///
 /// `MarcReader` reads one MARC record at a time from any source implementing [`std::io::Read`].
@@ -185,9 +193,11 @@ impl<R: Read> MarcReader<R> {
     }
 }
 
-impl MarcReader<std::fs::File> {
+impl MarcReader<std::io::BufReader<std::fs::File>> {
     /// Open `path` for reading and create a [`MarcReader`] whose errors
-    /// include the path as their `source_name`.
+    /// include the path as their `source_name`. Reads go through a 64 KiB
+    /// buffer, so the per-record read loop does not issue per-record
+    /// syscalls.
     ///
     /// # Errors
     ///
@@ -195,7 +205,8 @@ impl MarcReader<std::fs::File> {
     pub fn from_path(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
         let path = path.as_ref();
         let file = std::fs::File::open(path)?;
-        Ok(Self::new(file).with_source(path.display().to_string()))
+        let reader = std::io::BufReader::with_capacity(FILE_READ_BUF_CAPACITY, file);
+        Ok(Self::new(reader).with_source(path.display().to_string()))
     }
 }
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -34,6 +34,24 @@ def fixture_10k(fixture_dir):
 
 
 @pytest.fixture(scope="session")
+def fixture_1k_path(fixture_dir):
+    """Path to the 1k record fixture file on disk."""
+    path = fixture_dir / "1k_records.mrc"
+    if not path.exists():
+        pytest.skip(f"Fixture not found: {path}")
+    return str(path)
+
+
+@pytest.fixture(scope="session")
+def fixture_10k_path(fixture_dir):
+    """Path to the 10k record fixture file on disk."""
+    path = fixture_dir / "10k_records.mrc"
+    if not path.exists():
+        pytest.skip(f"Fixture not found: {path}")
+    return str(path)
+
+
+@pytest.fixture(scope="session")
 def fixture_small(fixture_1k):
     """Load small fixture (first 10 records from 1k fixture)."""
     # Create a small subset for quick tests

--- a/tests/python/test_benchmark_reading.py
+++ b/tests/python/test_benchmark_reading.py
@@ -41,6 +41,32 @@ class TestReadingBenchmarks:
         assert len(result) == 10000
     
     @pytest.mark.benchmark
+    def test_read_1k_records_from_path(self, benchmark, fixture_1k_path):
+        """Benchmark reading 1,000 records from a file path (RustFile backend)."""
+        def read_all():
+            reader = MARCReader(fixture_1k_path)
+            records = []
+            while (record := reader.read_record()) is not None:
+                records.append(record)
+            return records
+
+        result = benchmark(read_all)
+        assert len(result) == 1000
+
+    @pytest.mark.benchmark
+    def test_read_10k_records_from_path(self, benchmark, fixture_10k_path):
+        """Benchmark reading 10,000 records from a file path (RustFile backend)."""
+        def read_all():
+            reader = MARCReader(fixture_10k_path)
+            records = []
+            while (record := reader.read_record()) is not None:
+                records.append(record)
+            return records
+
+        result = benchmark(read_all)
+        assert len(result) == 10000
+
+    @pytest.mark.benchmark
     def test_read_and_extract_titles_1k(self, benchmark, fixture_1k):
         """Benchmark reading records and extracting titles."""
         def read_with_extraction():

--- a/tests/read_buffering_tests.rs
+++ b/tests/read_buffering_tests.rs
@@ -1,0 +1,110 @@
+//! Reads-per-record behavior of the MARC read loop.
+//!
+//! The per-record read loop issues at least two reads per record (leader,
+//! then body). On an unbuffered `File` each read is a syscall, so
+//! `from_path` wraps the file in a 64 KiB `BufReader`. These tests pin
+//! both halves of that claim by counting the reads that reach the
+//! underlying reader.
+
+use mrrc::MarcReader;
+use std::cell::Cell;
+use std::io::{BufReader, Cursor, Read};
+use std::rc::Rc;
+
+/// `Read` wrapper that counts calls reaching the underlying reader.
+///
+/// The counter is shared via `Rc<Cell<_>>` so it stays observable after
+/// the wrapper is moved into a `BufReader` or `MarcReader`.
+struct CountingReader<R> {
+    inner: R,
+    reads: Rc<Cell<usize>>,
+}
+
+impl<R: Read> Read for CountingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.reads.set(self.reads.get() + 1);
+        self.inner.read(buf)
+    }
+}
+
+fn fixture_1k() -> Vec<u8> {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/data/fixtures/1k_records.mrc"
+    );
+    std::fs::read(path).expect("1k_records.mrc fixture must exist")
+}
+
+fn drain<R: Read>(reader: &mut MarcReader<R>) -> usize {
+    let mut count = 0;
+    while let Ok(Some(_)) = reader.read_record() {
+        count += 1;
+    }
+    count
+}
+
+#[test]
+fn unbuffered_read_loop_issues_at_least_two_reads_per_record() {
+    let data = fixture_1k();
+    let reads = Rc::new(Cell::new(0));
+    let counting = CountingReader {
+        inner: Cursor::new(data),
+        reads: reads.clone(),
+    };
+
+    let mut reader = MarcReader::new(counting);
+    assert_eq!(drain(&mut reader), 1000);
+    assert!(
+        reads.get() >= 2000,
+        "expected >= 2 reads per record unbuffered, got {} for 1000 records",
+        reads.get()
+    );
+}
+
+#[test]
+fn buffered_read_loop_issues_one_read_per_buffer_fill() {
+    let data = fixture_1k();
+    let len = data.len();
+    let reads = Rc::new(Cell::new(0));
+    let counting = CountingReader {
+        inner: Cursor::new(data),
+        reads: reads.clone(),
+    };
+
+    // Same capacity from_path uses. Expected reads: one per 64 KiB
+    // buffer fill, plus one zero-byte read detecting EOF.
+    let mut reader = MarcReader::new(BufReader::with_capacity(64 * 1024, counting));
+    assert_eq!(drain(&mut reader), 1000);
+    let max_expected = len.div_ceil(64 * 1024) + 1;
+    assert!(
+        reads.get() <= max_expected,
+        "expected <= {} underlying reads ({} bytes through a 64 KiB buffer), got {}",
+        max_expected,
+        len,
+        reads.get()
+    );
+}
+
+#[test]
+fn from_path_reads_the_same_records_as_an_unbuffered_reader() {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/data/fixtures/1k_records.mrc"
+    );
+    let mut from_path = MarcReader::from_path(path).expect("fixture must open");
+    let mut unbuffered = MarcReader::new(Cursor::new(fixture_1k()));
+
+    loop {
+        let a = from_path.read_record().expect("from_path read");
+        let b = unbuffered.read_record().expect("cursor read");
+        match (a, b) {
+            (None, None) => break,
+            (Some(ra), Some(rb)) => assert_eq!(format!("{ra:?}"), format!("{rb:?}")),
+            (a, b) => panic!(
+                "readers diverged: from_path yielded {:?}, cursor yielded {:?}",
+                a.map(|_| "record"),
+                b.map(|_| "record")
+            ),
+        }
+    }
+}


### PR DESCRIPTION
The RustFile backend (`MARCReader(path)` in Python) and the Rust `from_path` constructors (bibliographic, authority, holdings) stored a raw `File`, so the per-record read loop issued at least two `read(2)` syscalls per record — 2M+ syscalls for a million records. Every file-path construction site now wraps the file in `BufReader::with_capacity(64 KiB)`. The Rust `from_path` constructors now return `MarcReader<BufReader<File>>` instead of `MarcReader<File>`.

## Wall-clock A/B (this machine, quiet)

Apple M4, macOS 26.5.1, rustc 1.95.0, Python 3.13.11, release wheel via `maturin develop --release`. `scripts/bench_read_throughput.py`, 5 measured runs per side, first run discarded as cache warm-up, median records/sec via `MARCReader(path)`:

| Fixture | main | this branch | delta |
|---|---|---|---|
| 10k records (2.5 MB) | 279,328 rec/s | 332,943 rec/s | **+19.2%** |
| 100k records (25 MB) | 278,743 rec/s | 329,915 rec/s | **+18.4%** |

## Instrumentation added with the fix

- File-path benchmarks (pytest-benchmark `MARCReader(path)` at 1k/10k; criterion `from_path` at 1k/10k) — the file-I/O loop previously had zero benchmark coverage on either side (everything read from BytesIO/Cursor), so CodSpeed now senses this path. Note CodSpeed's simulated instruction counts under-represent syscall savings; the wall-clock table above is the payoff measurement.
- `tests/read_buffering_tests.rs` pins the mechanism with a counting `Read` wrapper: ≥2 reads per record unbuffered, ~1 read per 64 KiB buffer fill buffered, and from_path/in-memory record equivalence. Placed in the core crate because `cargo test` cannot link mrrc-python (extension-module); the backend shares the same read loop.
- `scripts/bench_read_throughput.py` committed so per-PR A/B measurements in the read-path epic are reproducible; the mrrc-vs-pymarc comparison harness will extend it.

Closes #281

Bead: bd-0pg6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)