### PR TITLE
Run the release sdist smoke test outside the repo root

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -105,11 +105,16 @@ jobs:
           # Compiles the extension from source — proves the sdist is the
           # working fallback for platforms outside the wheel matrix.
           pip install dist/mrrc-*.tar.gz
+          # Run from outside the repo root: python -c puts the CWD on
+          # sys.path, and the source ./mrrc/ directory (no compiled
+          # extension) would shadow the installed package.
+          cd "$RUNNER_TEMP"
           python -c "
           import mrrc
-          records = list(mrrc.MARCReader(open('tests/data/simple_book.mrc','rb').read()))
+          data = open('$GITHUB_WORKSPACE/tests/data/simple_book.mrc','rb').read()
+          records = list(mrrc.MARCReader(data))
           assert len(records) == 1 and records[0].title == 'The Great Gatsby'
-          print('sdist install OK')
+          print('sdist install OK from', mrrc.__file__)
           "
 
   validate-cross-wheels:


### PR DESCRIPTION
The release dry run (run 27387761784) failed only in `test-sdist`: `python -c` puts the CWD on `sys.path`, so from the repo root the source `./mrrc/` directory — which has no compiled extension — shadowed the installed package, failing with a circular-import error. It had passed locally only because `maturin develop` leaves a `.so` in the source tree.

Run the smoke test from `RUNNER_TEMP`, reference the fixture via `GITHUB_WORKSPACE`, and print `mrrc.__file__` so the log shows which copy was imported. Everything else in the dry run passed: all 25 wheels including the new macOS universal2 builds, the sdist build itself, and the publish gating correctly skipped.

I'll re-trigger the dry run after this merges to confirm end-to-end.

Bead: bd-yfe6.1 (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)