### PR TITLE
check.sh: type-check benches instead of LTO-linking them

### DIFF
--- a/.cargo/check.sh
+++ b/.cargo/check.sh
@@ -74,8 +74,13 @@ if [ "$QUICK" = false ]; then
     cargo build --examples --quiet
 
     echo ""
-    echo "=== Compile benchmarks (no run) ==="
-    cargo bench --no-run --quiet
+    echo "=== Type-check benchmarks ==="
+    # cargo check skips codegen and linking: the bench profile inherits
+    # fat LTO + codegen-units=1, so `cargo bench --no-run` does a serial
+    # whole-program LTO link per bench target (minutes); type-checking
+    # catches the same compile errors in seconds. CodSpeed CI does the
+    # real LTO build.
+    cargo check --benches --quiet
 
     echo ""
     echo "=== Documentation check ==="


### PR DESCRIPTION
Fallout from #291: the bench profile now inherits fat LTO + codegen-units=1, so check.sh's `cargo bench --no-run` step started doing a serial whole-program LTO link for each of the seven bench targets — turning every pre-push hook run into a multi-minute single-core compile.

`cargo check --benches` catches the same compile errors (it type-checks all bench targets) without codegen or linking: ~3 seconds. The CodSpeed CI job still performs the real LTO bench build, so nothing loses coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)