### PR TITLE
Only cancel in-progress benchmark runs on pull requests

### DIFF
--- a/.github/workflows/benchmark-python.yml
+++ b/.github/workflows/benchmark-python.yml
@@ -22,7 +22,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   codspeed:

--- a/.github/workflows/benchmark-rust.yml
+++ b/.github/workflows/benchmark-rust.yml
@@ -27,7 +27,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   benchmarks:


### PR DESCRIPTION
Both benchmark workflows used cancel-in-progress: true keyed on workflow+ref, so back-to-back merges to main cancelled the previous merge commit's benchmark run. That killed the Python baseline run at commit 9b96f2c, and is why PR benchmark comparisons fall back to older base commits.

This changes cancel-in-progress to ${{ github.event_name == 'pull_request' }} in benchmark-python.yml and benchmark-rust.yml: superseded PR pushes still cancel their stale runs, while main-push baseline runs always complete.

Bead: bd-oayg.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)