### PR TITLE
Remove unused dependencies and demote example-only deps

### DIFF
--- a/.cargo/check.sh
+++ b/.cargo/check.sh
@@ -91,6 +91,13 @@ if [ "$QUICK" = false ]; then
     cargo audit
 
     echo ""
+    echo "=== Unused dependency check ==="
+    # Fix with: cargo install cargo-machete --locked
+    command -v cargo-machete &> /dev/null \
+        || { echo "ERROR: cargo-machete missing — run 'cargo install cargo-machete --locked'"; exit 1; }
+    cargo machete
+
+    echo ""
     if [ "$RELEASE" = true ]; then
         echo "=== Maturin Python extension build (--release) ==="
         # Release-mode codegen (inlining, optimizations) matches the wheels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Cargo.lock` is now committed, so CI, wheel builds, and local checkouts resolve the
   same dependency versions; Dependabot manages version bumps as reviewable diffs.
+- Removed unused dependencies (`bytes`, `nom`, `encoding_rs`, `csv`, bindings-crate
+  `tempfile`) and demoted example-only `anyhow`/`flate2` to dev-dependencies, shrinking
+  the published crate's dependency tree. check.sh now runs `cargo machete` to keep it so.
 - Record parsing no longer copies every record's bytes into the error-diagnostics
   buffer: the parse buffer is shared by refcount instead, deleting a per-record
   alloc+memcpy that every read path paid so that the under-1% of records that error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,12 +78,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,27 +296,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,15 +306,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "equivalent"
@@ -621,16 +585,12 @@ name = "mrrc"
 version = "0.8.2"
 dependencies = [
  "anyhow",
- "bytes",
  "codspeed-criterion-compat",
  "crossbeam-channel",
- "csv",
- "encoding_rs",
  "flate2",
  "indexmap",
  "insta",
  "memchr",
- "nom",
  "oxrdf",
  "oxrdfio",
  "proptest",
@@ -654,7 +614,6 @@ dependencies = [
  "pyo3",
  "serde_json",
  "smallvec",
- "tempfile",
 ]
 
 [[package]]
@@ -667,15 +626,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1085,12 +1035,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "ryu-js"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,12 +46,9 @@ default = []
 
 [dependencies]
 # Core parsing and data handling
-bytes = "1.11.1"
-nom = "8.0"
 memchr = "2.7"
 
 # Encoding support
-encoding_rs = "0.8"
 unicode-normalization = "0.1"
 
 # Serialization formats
@@ -63,15 +60,12 @@ quick-xml = { version = "0.40", features = ["serialize"] }
 indexmap = { version = "2.2", features = ["serde"] }
 
 # Error handling
-anyhow = "1.0"
 thiserror = "2.0"
 
 # Pattern matching
 regex = "1.10"
 
-# Examples and utilities
-csv = "1.3"
-flate2 = "1.0"
+# Inline small-vector storage for field/subfield collections
 smallvec = { version = "1.11", features = ["union", "serde"] }
 
 # Parallelism
@@ -87,9 +81,11 @@ proptest = "1.0"
 criterion = { version = "4.3.0", package = "codspeed-criterion-compat", features = ["html_reports"] }
 rayon = "1.7"
 tempfile = "3.8"
-smallvec = { version = "1.11", features = ["union", "serde"] }
 insta = "1"
 toml = "1.1"
+# Used by examples only (examples resolve against dev-dependencies)
+anyhow = "1.0"
+flate2 = "1.0"
 
 # Lint configuration following Rust API Guidelines
 [lints.rust]

--- a/src-python/Cargo.toml
+++ b/src-python/Cargo.toml
@@ -14,7 +14,6 @@ serde_json = "1.0"
 # Typical MARC records (100B-5KB) fit in 4KB inline buffer without allocation.
 # Larger records automatically spill to heap. ~85-90% of real-world records avoid allocation.
 smallvec = "1.11"
-tempfile = "3.0"
 
 [lib]
 name = "_mrrc"


### PR DESCRIPTION
## Summary

- Remove dependencies with zero usage: root-crate `bytes`, `nom`, `encoding_rs`, `csv` (the `csv::` references in source are mrrc's own module path, not the crates.io crate) and the bindings crate's `tempfile`.
- Demote `anyhow` and `flate2` to dev-dependencies — they are used only by `examples/marc_to_csv.rs`, and examples resolve against dev-dependencies.
- Drop the root `smallvec` dev-dependency that duplicated the regular dependency.
- Add a `cargo machete` step to check.sh (hard-required with an install hint, matching the existing pymarc-oracle pattern) so unused dependencies cannot accumulate again; the workspace is machete-clean.

Verified with `cargo check --workspace --all-targets`, `cargo build --package mrrc --all-targets`, and a full check.sh run. Note: `cargo build --workspace --all-targets` fails identically before and after this change — the bindings crate's pyo3 `extension-module` feature leaves libpython symbols unresolved when cargo links its standalone test binaries outside maturin; that is pre-existing and unrelated.

Bead: bd-yfe6.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)