### PR TITLE
Make the release pipeline idempotent and rehearsable

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -5,8 +5,19 @@ on:
     tags:
       - 'v*'
   # Dry run: builds and tests every artifact (wheels, sdist) without
-  # publishing — the publish/release steps are gated on tag refs.
+  # publishing to PyPI — the PyPI publish and GitHub Release steps are
+  # gated on tag refs. Selecting publish-target=testpypi additionally
+  # rehearses the publish against TestPyPI (requires a TestPyPI trusted
+  # publisher configured for this repository and workflow).
   workflow_dispatch:
+    inputs:
+      publish-target:
+        description: "none = build/test only; testpypi = rehearsal publish to TestPyPI"
+        type: choice
+        options:
+          - none
+          - testpypi
+        default: none
 
 jobs:
   build-release-wheels:
@@ -153,6 +164,60 @@ jobs:
             exit 1
           fi
 
+  # The filename check above covers all 10 cross-compiled wheels; this job
+  # additionally installs and imports one representative wheel per target
+  # inside a matching container, so a wheel that builds but cannot load
+  # (bad linkage, wrong interpreter ABI) fails before publish.
+  smoke-test-cross-wheels:
+    name: Import-smoke ${{ matrix.target }} wheel (Python 3.12)
+    needs: build-cross-linux-wheels
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [aarch64-unknown-linux-gnu, i686-unknown-linux-gnu]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: release-wheels-${{ matrix.target }}-3.12
+          path: dist
+
+      - name: Set up QEMU (aarch64 emulation)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Write import-smoke script
+        run: |
+          # Executed with python -I so neither the CWD nor the script
+          # directory lands on sys.path; otherwise the source ./mrrc/
+          # directory (no compiled extension) shadows the installed wheel.
+          cat > smoke.py <<'EOF'
+          import mrrc
+          data = open("tests/data/simple_book.mrc", "rb").read()
+          records = list(mrrc.MARCReader(data))
+          assert len(records) == 1
+          assert records[0].title == "The Great Gatsby"
+          print("wheel import OK:", mrrc.__file__)
+          EOF
+
+      - name: Import-smoke aarch64 wheel under QEMU
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          docker run --rm --platform linux/arm64 -v "$PWD":/work -w /work \
+            python:3.12-slim \
+            sh -c 'pip install --no-cache-dir dist/*.whl && python -I smoke.py'
+
+      - name: Import-smoke i686 wheel in 32-bit container
+        if: matrix.target == 'i686-unknown-linux-gnu'
+        run: |
+          # i686 binaries run natively on the x86_64 runner kernel; linux32
+          # sets the uname personality so pip accepts the i686 wheel tag.
+          docker run --rm --platform linux/386 -v "$PWD":/work -w /work \
+            quay.io/pypa/manylinux2014_i686 \
+            linux32 sh -c '/opt/python/cp312-cp312/bin/pip install --no-cache-dir dist/*.whl && /opt/python/cp312-cp312/bin/python -I smoke.py'
+
   test-release-wheels:
     name: Test release wheels on ${{ matrix.os }}
     needs: build-release-wheels
@@ -218,10 +283,45 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [test-release-wheels, validate-cross-wheels, test-sdist]
+    needs: [test-release-wheels, validate-cross-wheels, smoke-test-cross-wheels, test-sdist]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          # Collects release-wheels-* and release-sdist.
+          pattern: release-*
+          path: dist
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -l dist/
+
+      - name: Publish to PyPI
+        # Skipped on workflow_dispatch runs; only tag pushes publish.
+        # skip-existing makes re-runs after a partial failure upload only
+        # the missing files instead of dying on "file already exists".
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+      - name: Publish to TestPyPI (rehearsal)
+        if: github.event_name == 'workflow_dispatch' && inputs.publish-target == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  # Separate job so a GitHub Release failure can be re-run without
+  # re-entering the PyPI publish path, and vice versa.
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6.0.3
@@ -237,8 +337,6 @@ jobs:
           merge-multiple: true
 
       - name: Extract release notes from CHANGELOG
-        id: changelog
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           # Extract the section for this version (between its header and the next ## header)
@@ -246,20 +344,8 @@ jobs:
           # Write to file to avoid shell quoting issues
           echo "$NOTES" > release_notes.md
 
-      - name: Publish to PyPI
-        # Skipped on workflow_dispatch dry runs; only tag pushes publish.
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-      - name: List artifacts (dry run)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          echo "Dry run — artifacts that a tag push would publish:"
-          ls -l dist/
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: dist/*
           body_path: release_notes.md

--- a/docs/contributing/release-procedure.md
+++ b/docs/contributing/release-procedure.md
@@ -905,8 +905,12 @@ Look for the "Python Release to PyPI" workflow:
 2. **build-cross-linux-wheels** job - Cross-compiles aarch64 and i686 Linux wheels for Python 3.10-3.14 (10 wheels)
 3. **build-sdist** / **test-sdist** jobs - Build the source distribution and prove it compiles and
    imports in a clean environment (the fallback for platforms outside the wheel matrix)
-4. **test-release-wheels** / **validate-cross-wheels** jobs - Test native wheels; validate cross-compiled wheel tags
-5. **publish-pypi** job - Publishes all wheels plus the sdist to PyPI
+4. **test-release-wheels** / **validate-cross-wheels** / **smoke-test-cross-wheels** jobs - Test
+   native wheels; validate cross-compiled wheel tags; install and import one representative
+   cross-compiled wheel per target (aarch64 under QEMU, i686 in a 32-bit container)
+5. **publish-pypi** job - Publishes all wheels plus the sdist to PyPI (`skip-existing`, so a re-run
+   after a partial failure uploads only the missing files)
+6. **github-release** job - Creates the GitHub Release with artifacts and CHANGELOG notes
 
 Each job has multiple matrix runs (fail-fast: false means all run even if some fail).
 
@@ -1362,7 +1366,7 @@ twine upload dist/mrrc-*.whl
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `python-release.yml` | Tag push `v*` | Builds wheels, tests, publishes to PyPI |
+| `python-release.yml` | Tag push `v*`; manual dispatch | Builds wheels, tests, publishes to PyPI; dispatch is a dry run, or a TestPyPI rehearsal with `publish-target=testpypi` |
 | `lint.yml` | Push/PR | Rustfmt, clippy, doc checks |
 | `test.yml` | Push/PR | Cargo tests |
 | `python-build.yml` | Push/PR | Python wheel build test |


### PR DESCRIPTION
Re-running a partially failed release died on "file already exists": all 25 wheels publish in one invocation without skip-existing, and the GitHub Release step shared the publish job, so the documented remedy (re-tag) collided identically. Cross-compiled wheels (10 of 25) were validated by filename grep only and never imported before publish, and no TestPyPI rehearsal existed, so first contact with PyPI validation was the production publish.

Changes to python-release.yml:

- `skip-existing: true` on the PyPI publish step, so a re-run after a partial failure uploads only the missing files instead of failing.
- GitHub Release creation moves into its own `github-release` job (needs `publish-pypi`) with `contents: write`; `publish-pypi` drops to `id-token: write` only. Either half can be re-run without re-entering the other.
- New `smoke-test-cross-wheels` job gates publish: installs and imports one representative (Python 3.12) cross-compiled wheel per target — aarch64 under QEMU in a `python:3.12-slim` arm64 container, i686 in the `quay.io/pypa/manylinux2014_i686` linux/386 container under `linux32`. The existing filename validation for all 10 cross wheels is unchanged.
- `workflow_dispatch` gains a `publish-target` input (`none` default keeps the existing dry-run behavior; `testpypi` rehearses the publish against TestPyPI with `skip-existing`). Manual setup needed before first rehearsal: configure a TestPyPI trusted publisher for this repository and workflow.
- release-procedure.md: the monitored-job list and workflow table updated to match the new pipeline shape.

Note: the bead also pointed at a residual "(15 wheels present)" in release-procedure.md; that line already reads "25 wheels + 1 sdist present", so no fix was needed.

Bead: bd-oayg.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)