### PR TITLE
Notify on scheduled CI failures, persist the fuzz corpus, schedule cargo-audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,77 @@
+name: Security Audit
+
+# cargo-audit on pushes and PRs, plus a daily schedule so an advisory
+# published during a quiet stretch surfaces the next morning instead of
+# at the next push. A scheduled failure files (or comments on) a
+# tracking issue.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.beads/**'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.beads/**'
+  schedule:
+    # Daily at 05:00 UTC, offset from the other scheduled workflows
+    # (ASAN 02:00, fuzz 03:00, Miri 06:00).
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
+
+      - name: Run security audit
+        run: cargo audit
+
+  notify-failure:
+    name: File failure issue
+    needs: security-audit
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File or update the failure-tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Scheduled cargo-audit run failed"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --json number,title \
+            --jq '[.[] | select(.title == env.TITLE)][0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Failed again: $RUN_URL"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" \
+              --body "Scheduled run failed: $RUN_URL — likely a new RustSec advisory against a locked dependency. Later failures will be added here as comments."
+          fi

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,8 +7,11 @@ name: Fuzz (nightly)
 #   - Runs nightly + on demand (workflow_dispatch); not a PR gate.
 #   - A crash FAILS the job so the red mark surfaces on the Actions
 #     dashboard. fuzz/artifacts/* uploads so the reproducer survives.
-#   - Triage is manual. No auto-filing. Reproducers get copied into
-#     tests/ as regressions — see docs/contributing/fuzzing.md.
+#   - A scheduled failure files (or comments on) a tracking issue so it
+#     cannot pass unnoticed. Triage is manual. Reproducers get copied
+#     into tests/ as regressions — see docs/contributing/fuzzing.md.
+#   - The grown corpus is cached per target across runs so coverage
+#     depth compounds instead of regrowing from the committed seeds.
 
 on:
   schedule:
@@ -63,6 +66,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-fuzz-
 
+      - name: Cache fuzz corpus
+        uses: actions/cache@v5
+        with:
+          path: fuzz/corpus/${{ matrix.target }}
+          # The run-scoped key never matches an existing entry, so every
+          # run restores the newest corpus via restore-keys and saves its
+          # own grown corpus as a fresh entry. The committed seeds merge
+          # in from checkout either way.
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
       - name: Run ${{ matrix.target }}
         env:
           MAX_TOTAL_TIME: ${{ github.event.inputs.max_total_time || '300' }}
@@ -74,6 +89,12 @@ jobs:
         # incompatible with `-Zsanitizer=address` (static libc).
         run: cargo +nightly fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=$MAX_TOTAL_TIME
 
+      - name: Minimize corpus before caching
+        # Sheds redundant inputs while keeping coverage, so the cached
+        # corpus stays small enough for fast libfuzzer startup. Skipped
+        # when the fuzz run failed (the cache also skips saving then).
+        run: cargo +nightly fuzz cmin ${{ matrix.target }} --target x86_64-unknown-linux-gnu
+
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@v7
@@ -82,3 +103,28 @@ jobs:
           path: fuzz/artifacts/
           if-no-files-found: warn
           retention-days: 30
+
+  notify-failure:
+    name: File failure issue
+    needs: fuzz
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File or update the failure-tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Nightly fuzz run failed"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --json number,title \
+            --jq '[.[] | select(.title == env.TITLE)][0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Failed again: $RUN_URL"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" \
+              --body "Scheduled run failed: $RUN_URL — crash artifacts (if any) are attached to the run. Later failures will be added here as comments. Triage playbook: docs/contributing/fuzzing.md."
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -135,22 +135,6 @@ jobs:
       - name: Run stubtest
         run: uv run python -m mypy.stubtest mrrc._mrrc
 
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v6.0.3
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
-
-      - name: Run security audit
-        run: cargo audit
-
   msrv:
     name: MSRV check
     runs-on: ubuntu-latest

--- a/.github/workflows/memory-safety.yml
+++ b/.github/workflows/memory-safety.yml
@@ -51,3 +51,28 @@ jobs:
       - name: Report results
         if: always()
         run: echo "ASAN tests completed. Check output above for any issues."
+
+  notify-failure:
+    name: File failure issue
+    needs: asan-library-tests
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File or update the failure-tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Nightly ASAN run failed"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --json number,title \
+            --jq '[.[] | select(.title == env.TITLE)][0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Failed again: $RUN_URL"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" \
+              --body "Scheduled run failed: $RUN_URL. Later failures will be added here as comments."
+          fi

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -35,3 +35,28 @@ jobs:
           # Prevent insta from spawning `cargo metadata` to discover the
           # workspace root — Miri can't execute subprocesses (no pidfd_spawnp).
           INSTA_WORKSPACE_ROOT: ${{ github.workspace }}
+
+  notify-failure:
+    name: File failure issue
+    needs: miri
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: File or update the failure-tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Nightly Miri run failed"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --json number,title \
+            --jq '[.[] | select(.title == env.TITLE)][0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Failed again: $RUN_URL"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" \
+              --body "Scheduled run failed: $RUN_URL. Later failures will be added here as comments."
+          fi

--- a/docs/contributing/fuzzing.md
+++ b/docs/contributing/fuzzing.md
@@ -166,8 +166,14 @@ seeds (the `-X` flag means "only ignored files"):
 git clean -fdX fuzz/corpus/parse_record/
 ```
 
-CI runners start fresh each nightly run and throw away mutator adds when
-the runner tears down, so no cleanup is needed there.
+In CI the grown corpus persists across nightly runs through an
+`actions/cache` entry per fuzz target, so coverage depth compounds
+instead of regrowing from the committed seeds. Each run minimizes the
+corpus (`cargo fuzz cmin`) before caching, which keeps the entries
+small; no manual cleanup is needed there. To fold accumulated CI
+coverage back into the committed seeds, occasionally run `cmin`
+locally on a corpus that includes the cached CI inputs and commit the
+survivors as new seeds (with matching `fuzz/.gitignore` allow lines).
 
 ## Playbook: investigating a CI failure
 


### PR DESCRIPTION
The fuzz, Miri, and ASAN nightlies fail silently for a solo maintainer (and GitHub auto-disables cron workflows after 60 days of repo inactivity, so a quiet failure can become no runs at all). The fuzz corpus regrew from the 26 committed seeds every night and was discarded at teardown, so coverage depth never compounded. cargo-audit ran only on push/PR, so an advisory published during a quiet stretch surfaced only at the next push.

- fuzz.yml, miri.yml, memory-safety.yml: a `notify-failure` job (scoped `issues: write`) runs when a scheduled run fails; it files a tracking issue, or comments "Failed again" with the run URL on the already-open one, so repeat failures dedupe into one issue. workflow_dispatch failures stay silent since someone is watching those.
- fuzz.yml: per-target `actions/cache` on `fuzz/corpus/<target>` with a run-scoped key plus restore-keys — each night restores the newest corpus and saves its grown one — and a `cargo fuzz cmin` step before caching keeps entries small. The cache action skips saving when the fuzz run failed, so a crash night does not poison the corpus.
- security-audit moves from lint.yml into a new audit.yml with the same push/PR triggers plus a daily 05:00 UTC schedule (offset from ASAN 02:00, fuzz 03:00, Miri 06:00), workflow_dispatch, and the same scheduled-failure issue filing.
- docs/contributing/fuzzing.md: the corpus-management section now describes CI persistence and how to fold accumulated CI coverage back into the committed seeds with a local cmin pass.

Bead: bd-oayg.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)