### PR TITLE
Run the Rust test suite on an OS matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,16 @@ concurrency:
 
 jobs:
   test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    name: Test Suite (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # All three OSes on every run: platform-sensitive paths (from_path,
+    # file I/O, the rayon pipeline) get Rust-level coverage on macOS and
+    # Windows instead of relying on the Python wheel suite alone.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-2025]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6.0.3
 


### PR DESCRIPTION
test.yml ran on Linux only, so cross-platform signal came entirely from the Python wheel suite; platform-sensitive paths exercised by pure-Rust consumers (from_path, file I/O, the rayon pipeline) were never tested on macOS or Windows as Rust.

The test job now runs on ubuntu-latest, macos-latest, and windows-2025 (matching the OS set python-build.yml uses) with fail-fast disabled, covering cargo tests, doc tests, and example builds on each OS. Timeout raised 20 → 30 minutes for the slower Windows builds. This PR's own CI run is the first cross-OS execution of the Rust suite.

Bead: bd-oayg.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)