### PR TITLE
Single-source the version and shared manifest fields via workspace inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unused dependencies (`bytes`, `nom`, `encoding_rs`, `csv`, bindings-crate
   `tempfile`) and demoted example-only `anyhow`/`flate2` to dev-dependencies, shrinking
   the published crate's dependency tree. check.sh now runs `cargo machete` to keep it so.
+- The version is now declared once, in `[workspace.package]`: both crates inherit it and
+  `pyproject.toml` reads it via `dynamic = ["version"]`. Shared dependencies and
+  `rust-version` are also workspace-inherited, so they cannot drift between crates.
 - Record parsing no longer copies every record's bytes into the error-diagnostics
   buffer: the parse buffer is shared by refcount instead, deleting a per-record
   alloc+memcpy that every read path paid so that the under-1% of records that error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,18 +2,36 @@
 members = [".", "src-python"]
 resolver = "3"
 
-[package]
-name = "mrrc"
+# Single source of truth for fields shared by both crates. The Python
+# package version is also derived from here: pyproject.toml declares
+# `dynamic = ["version"]` and maturin reads src-python/Cargo.toml,
+# which inherits this version.
+[workspace.package]
 version = "0.8.2"
 edition = "2024"
+rust-version = "1.88"
 authors = ["Daniel Chudnov"]
-description = "A Rust library for reading, writing, and manipulating MARC bibliographic records in ISO 2709 binary format"
 license = "MIT"
 repository = "https://github.com/dchud/mrrc"
+
+# Dependencies used by both crates, declared once so versions and
+# features cannot drift between them.
+[workspace.dependencies]
+serde_json = "1.0"
+smallvec = { version = "1.11", features = ["union", "serde"] }
+
+[package]
+name = "mrrc"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "A Rust library for reading, writing, and manipulating MARC bibliographic records in ISO 2709 binary format"
+license.workspace = true
+repository.workspace = true
 homepage = "https://github.com/dchud/mrrc"
 documentation = "https://docs.rs/mrrc"
 readme = "README.md"
-rust-version = "1.88"
+rust-version.workspace = true
 keywords = ["marc", "bibliographic", "library", "metadata"]
 categories = ["encoding", "parser-implementations"]
 
@@ -53,7 +71,7 @@ unicode-normalization = "0.1"
 
 # Serialization formats
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { workspace = true }
 quick-xml = { version = "0.40", features = ["serialize"] }
 
 # Ordered map for insertion order preservation
@@ -66,7 +84,7 @@ thiserror = "2.0"
 regex = "1.10"
 
 # Inline small-vector storage for field/subfield collections
-smallvec = { version = "1.11", features = ["union", "serde"] }
+smallvec = { workspace = true }
 
 # Parallelism
 rayon = "1.7"

--- a/docs/contributing/release-procedure.md
+++ b/docs/contributing/release-procedure.md
@@ -30,9 +30,9 @@ When a coding agent receives a task "prepare release version X.Y.Z", it should f
 ### Machine-Checkable Success Criteria
 
 ```bash
-# 1. All version files updated and matching
-ROOT_VER=$(sed -n '/^\[package\]/,/^\[/p' Cargo.toml | grep '^version' | sed 's/.*"\([^"]*\)".*/\1/')
-[ "$ROOT_VER" = "$VERSION" ] || exit 1
+# 1. Workspace version updated (single source: [workspace.package] in Cargo.toml)
+WS_VER=$(sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml | grep '^version' | sed 's/.*"\([^"]*\)".*/\1/')
+[ "$WS_VER" = "$VERSION" ] || exit 1
 
 # 2. CHANGELOG.md structure correct
 [ "$(grep -c "## \[Unreleased\]" CHANGELOG.md)" = "1" ] || exit 1
@@ -68,9 +68,9 @@ bash << 'EOF'
 set -e
 echo "Checking release preparation..."
 
-# Versions
-ROOT=$(sed -n '/^\[package\]/,/^\[/p' Cargo.toml | grep '^version' | sed 's/.*"\([^"]*\)".*/\1/')
-[ "$ROOT" = "$VERSION" ] && echo "✓ Versions match" || (echo "✗ Version mismatch" && exit 1)
+# Version (single source: [workspace.package] in Cargo.toml)
+WS=$(sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml | grep '^version' | sed 's/.*"\([^"]*\)".*/\1/')
+[ "$WS" = "$VERSION" ] && echo "✓ Versions match" || (echo "✗ Version mismatch" && exit 1)
 
 # Changelog
 [ "$(grep -c "## \[Unreleased\]" CHANGELOG.md)" = "1" ] && echo "✓ Changelog structure OK" || (echo "✗ Changelog issue" && exit 1)
@@ -333,10 +333,10 @@ MRRC currently uses **Semantic Versioning (SemVer)**: `MAJOR.MINOR.PATCH`
 - **MINOR** (e.g., 0.4.0 → 0.5.0): New features, backward-compatible API additions
 - **MAJOR** (e.g., 0.4.0 → 1.0.0): Breaking changes, significant redesigns
 
-**Current version**: Check `Cargo.toml`:
+**Current version**: Check `[workspace.package]` in `Cargo.toml`:
 
 ```bash
-grep '^version' Cargo.toml
+sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml | grep '^version'
 ```
 
 ### 2.2 Document Version Rationale
@@ -347,110 +347,57 @@ Note the reason for the chosen version increment in your release notes/commit me
 
 ## Update Configuration Files
 
-Update version numbers in all configuration files. **Do this in order** and **verify each file** before proceeding.
+The version is declared once, in `[workspace.package]` in the root `Cargo.toml`. Both crates inherit it (`version.workspace = true`), and `pyproject.toml` declares `dynamic = ["version"]`, so maturin reads the same value. One edit updates everything.
 
 The VERSION variable is used throughout. Ensure `$VERSION` is set before starting (see [Preflight Dependencies](#preflight-dependencies-setup)).
 
-### 3.1 Update Root Cargo.toml
+### 3.1 Update the Workspace Version
 
 **File**: `Cargo.toml` (in repo root)
 
-Find the `[package]` section (should be near the top) and update the `version` field:
+Update the `version` field in the `[workspace.package]` section:
 
 ```bash
 # Show current version
-echo "=== Current Root Cargo.toml version ==="
-sed -n '/^\[package\]/,/^\[/p' Cargo.toml | grep '^version'
+echo "=== Current workspace version ==="
+sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml | grep '^version'
 
 # Update version (using sed)
-sed -i.bak '/^\[package\]/,/^\[/{
+sed -i.bak '/^\[workspace\.package\]/,/^\[/{
   s/^version = .*/version = "'$VERSION'"/
 }' Cargo.toml
 
+# Refresh the committed Cargo.lock so it records the new crate versions
+cargo update --workspace --quiet
+
 # Verify
-echo "=== Updated Root Cargo.toml version ==="
-sed -n '/^\[package\]/,/^\[/p' Cargo.toml | grep '^version'
+echo "=== Updated workspace version ==="
+sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml | grep '^version'
 ```
 
 **Checklist**:
 
-- [ ] Root Cargo.toml updated
-- [ ] Version number shows `version = "X.Y.Z"` where X.Y.Z matches $VERSION
+- [ ] `[workspace.package]` shows `version = "X.Y.Z"` where X.Y.Z matches $VERSION
 - [ ] No other section's version was changed
+- [ ] Cargo.lock shows both `mrrc` and `mrrc-python` at the new version
 
-### 3.2 Update Python Cargo.toml
-
-**File**: `src-python/Cargo.toml`
-
-Update the version in the `[package]` section to match the root version:
-
-```bash
-# Show current version
-echo "=== Current Python Cargo.toml version ==="
-sed -n '/^\[package\]/,/^\[/p' src-python/Cargo.toml | grep '^version'
-
-# Update version
-sed -i.bak 's/^version = .*/version = "'$VERSION'"/' src-python/Cargo.toml
-
-# Verify
-echo "=== Updated Python Cargo.toml version ==="
-grep '^version' src-python/Cargo.toml
-```
-
-**Checklist**:
-
-- [ ] Python Cargo.toml updated
-- [ ] Version number matches root (should show `version = "X.Y.Z"`)
-
-### 3.3 Update pyproject.toml
-
-**File**: `pyproject.toml` (in repo root)
-
-Update the version in the `[project]` section:
-
-```bash
-# Show current version
-echo "=== Current pyproject.toml version ==="
-sed -n '/^\[project\]/,/^\[/p' pyproject.toml | grep '^version'
-
-# Update version
-sed -i.bak 's/^version = .*/version = "'$VERSION'"/' pyproject.toml
-
-# Verify
-echo "=== Updated pyproject.toml version ==="
-sed -n '/^\[project\]/,/^\[/p' pyproject.toml | grep '^version'
-```
-
-**Checklist**:
-
-- [ ] pyproject.toml updated
-- [ ] Version number matches root and Python Cargo.toml
-
-### 3.4 Verify All Versions Match
+### 3.2 Verify Both Crates Inherit the New Version
 
 ```bash
 echo "=== Version Consistency Check ==="
-ROOT_VER=$(sed -n '/^\[package\]/,/^\[/p' Cargo.toml | grep '^version' | head -1 | sed 's/.*= "\([^"]*\)".*/\1/')
-PYTHON_VER=$(grep '^version' src-python/Cargo.toml | head -1 | sed 's/.*= "\([^"]*\)".*/\1/')
-PYPROJECT_VER=$(sed -n '/^\[project\]/,/^\[/p' pyproject.toml | grep '^version' | head -1 | sed 's/.*= "\([^"]*\)".*/\1/')
+cargo metadata --format-version 1 --no-deps \
+  | jq -r '.packages[] | "\(.name) \(.version)"'
+echo "Expected: mrrc $VERSION and mrrc-python $VERSION"
 
-echo "Root Cargo.toml: $ROOT_VER"
-echo "Python Cargo.toml: $PYTHON_VER"
-echo "pyproject.toml: $PYPROJECT_VER"
-echo "Expected: $VERSION"
-
-# Exit with failure if any don't match
-if [ "$ROOT_VER" != "$VERSION" ] || [ "$PYTHON_VER" != "$VERSION" ] || [ "$PYPROJECT_VER" != "$VERSION" ]; then
-  echo "ERROR: Version mismatch detected!"
-  exit 1
-fi
-echo "✓ All versions match"
+cargo metadata --format-version 1 --no-deps \
+  | jq -e --arg v "$VERSION" 'all(.packages[]; .version == $v)' >/dev/null \
+  && echo "✓ All versions match" \
+  || { echo "ERROR: Version mismatch detected!"; exit 1; }
 ```
 
 **Checklist**:
 
-- [ ] All three version numbers are identical
-- [ ] All match the $VERSION variable
+- [ ] Both crates report the new version
 - [ ] Script exits with success (code 0)
 
 ---
@@ -693,11 +640,9 @@ Before committing version changes and creating the git tag, perform one final ve
 ### 6.0 Final Verification
 
 ```bash
-# 1. Verify all version files match
+# 1. Verify both crates report the workspace version
 echo "=== Version Check ==="
-echo "Root: $(grep '^version' Cargo.toml)"
-echo "Python Cargo: $(grep '^version' src-python/Cargo.toml)"
-echo "PyProject: $(grep '^version' pyproject.toml)"
+cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | "\(.name) \(.version)"'
 
 # 2. Verify changelog was updated
 echo ""
@@ -714,7 +659,7 @@ All checks must pass before proceeding to git operations.
 
 **Checklist**:
 
-- [ ] All three version numbers are identical
+- [ ] Both crates report the new version (inherited from `[workspace.package]`)
 - [ ] Changelog shows new version with today's date
 - [ ] All tests pass
 - [ ] Git status is clean (only version files changed)
@@ -730,12 +675,12 @@ All checks must pass before proceeding to git operations.
 Remove the `.bak` files created by sed during version updates:
 
 ```bash
-rm -f Cargo.toml.bak src-python/Cargo.toml.bak pyproject.toml.bak CHANGELOG.md.bak
+rm -f Cargo.toml.bak CHANGELOG.md.bak
 ```
 
 **Checklist**:
 
-- [ ] No `.bak` files remain in repository root or src-python/
+- [ ] No `.bak` files remain in the repository root
 
 ---
 
@@ -781,7 +726,7 @@ Stage and commit the updated files:
 
 ```bash
 # Stage the exact files we modified
-git add Cargo.toml src-python/Cargo.toml pyproject.toml CHANGELOG.md
+git add Cargo.toml Cargo.lock CHANGELOG.md
 
 # Verify staging
 echo "=== Staged changes ==="
@@ -790,7 +735,7 @@ git diff --cached --stat
 # Commit with clear message
 git commit -m "chore(release): v$VERSION
 
-- Update Cargo.toml, src-python/Cargo.toml, pyproject.toml to $VERSION
+- Update workspace version to $VERSION (both crates and the Python package inherit it)
 - Update CHANGELOG.md with release notes and date ($RELEASE_DATE)
 - All pre-release checks passing, ready for publication"
 
@@ -801,7 +746,7 @@ git log --oneline -1
 
 **Checklist**:
 
-- [ ] Only these 4 files staged: Cargo.toml, src-python/Cargo.toml, pyproject.toml, CHANGELOG.md
+- [ ] Only these 3 files staged: Cargo.toml, Cargo.lock, CHANGELOG.md
 - [ ] Commit message includes version number
 - [ ] `git log --oneline -1` shows the new commit
 - [ ] Git status shows nothing to commit
@@ -1250,14 +1195,14 @@ twine upload dist/mrrc-*.whl
 4. **Do NOT re-release**: docs.rs will automatically rebuild the docs for the existing version within a few minutes
 5. Verify rebuild by checking the page again
 
-### Version Mismatch Between Cargo/PyProject
+### Version Mismatch Between Crate and Wheel
 
-**Problem**: Deployment uses version A in Cargo.toml but version B in pyproject.toml
+**Problem**: A published artifact reports a version different from `[workspace.package]`
 
 **Steps**:
-1. Verify all three configs match: `Cargo.toml`, `src-python/Cargo.toml`, `pyproject.toml`
+1. The version has a single source: `[workspace.package]` in the root `Cargo.toml`. Both crates inherit it and `pyproject.toml` is `dynamic = ["version"]`, so a mismatch means the artifact was built from a stale checkout or a tag pointing at the wrong commit.
 2. If mismatch exists:
-   - Fix all to the same version
+   - Fix the workspace version
    - Delete the incorrect tag: `git tag -d vX.Y.Z && git push origin :refs/tags/vX.Y.Z`
    - Recommit and retag (see GitHub Actions Build Fails section)
 
@@ -1293,10 +1238,9 @@ twine upload dist/mrrc-*.whl
 
 **Phase 3: Configuration File Updates**
 
-- [ ] Cargo.toml updated
-- [ ] src-python/Cargo.toml updated
-- [ ] pyproject.toml updated
-- [ ] All three versions match
+- [ ] `[workspace.package]` version in Cargo.toml updated
+- [ ] Cargo.lock refreshed (`cargo update --workspace`)
+- [ ] Both crates report the new version (`cargo metadata`)
 
 **Phase 4: Changelog & Documentation**
 
@@ -1309,7 +1253,7 @@ twine upload dist/mrrc-*.whl
 
 **Phase 5: Final Sanity Check**
 
-- [ ] Version consistency verified (all three files match)
+- [ ] Version consistency verified (both crates inherit the workspace version)
 - [ ] Changelog shows new version with correct date
 - [ ] All tests pass (full `.cargo/check.sh`)
 - [ ] Git status is clean (only config files changed)
@@ -1352,10 +1296,10 @@ twine upload dist/mrrc-*.whl
 
 | File | Purpose | Version String |
 |------|---------|-----------------|
-| `Cargo.toml` | Root Rust package | Line 7: `version = "X.Y.Z"` |
-| `src-python/Cargo.toml` | Python binding package | Line 3: `version = "X.Y.Z"` |
-| `pyproject.toml` | Python project metadata | Line 7: `version = "X.Y.Z"` |
-| `CHANGELOG.md` | Release notes | Line 8+: Version headers |
+| `Cargo.toml` | Workspace root | `[workspace.package]` `version = "X.Y.Z"` — the single source |
+| `src-python/Cargo.toml` | Python binding package | `version.workspace = true` (inherited, no edit) |
+| `pyproject.toml` | Python project metadata | `dynamic = ["version"]` (read by maturin, no edit) |
+| `CHANGELOG.md` | Release notes | Version headers |
 | `README.md` | Project overview | Various (checked for version refs) |
 
 ### GitHub Actions Workflows
@@ -1385,10 +1329,9 @@ twine upload dist/mrrc-*.whl
 # Pre-release verification
 .cargo/check.sh
 
-# Version checks
-grep '^version' Cargo.toml
-grep '^version' src-python/Cargo.toml
-grep '^version' pyproject.toml
+# Version checks (single source: [workspace.package] in Cargo.toml)
+sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml | grep '^version'
+cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | "\(.name) \(.version)"'
 
 # Git operations
 git tag -a vX.Y.Z -m "Release version X.Y.Z"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ build-backend = "maturin"
 
 [project]
 name = "mrrc"
-version = "0.8.2"
+# The version comes from [workspace.package] in the root Cargo.toml:
+# maturin reads src-python/Cargo.toml (manifest-path below), which
+# inherits the workspace version.
+dynamic = ["version"]
 description = "MRRC: A fast MARC library written in Rust with Python bindings"
 readme = "README.md"
 # PEP 639 license expression; the license classifier is omitted per PEP 639.

--- a/src-python/Cargo.toml
+++ b/src-python/Cargo.toml
@@ -1,19 +1,21 @@
 [package]
 name = "mrrc-python"
-version = "0.8.2"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
 description = "PyO3 bindings for the mrrc MARC library"
-license = "MIT"
-repository = "https://github.com/dchud/mrrc"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pyo3 = { version = "0.29", features = ["extension-module"] }
 mrrc = { path = ".." }
-serde_json = "1.0"
+serde_json = { workspace = true }
 # SmallVec for buffered reader: we own the bytes here to safely cross the GIL boundary.
 # Typical MARC records (100B-5KB) fit in 4KB inline buffer without allocation.
 # Larger records automatically spill to heap. ~85-90% of real-world records avoid allocation.
-smallvec = "1.11"
+smallvec = { workspace = true }
 
 [lib]
 name = "_mrrc"

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,6 @@ wheels = [
 
 [[package]]
 name = "mrrc"
-version = "0.8.2"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -652,7 +651,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'benchmark'", specifier = ">=2.0" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'test'", specifier = ">=2.0" },
 ]
-provides-extras = ["test", "dev", "benchmark", "docs", "oracle"]
+provides-extras = ["benchmark", "dev", "docs", "oracle", "test"]
 
 [[package]]
 name = "mypy"


### PR DESCRIPTION
## Summary

- Declare `version`, `edition`, `rust-version`, `authors`, `license`, and `repository` once in `[workspace.package]`; both crates inherit them. `src-python/Cargo.toml` previously had no `rust-version` at all — it now inherits the workspace MSRV.
- Move shared dependencies (`serde_json`, `smallvec`) to `[workspace.dependencies]` so versions and features cannot drift between the crates (they previously had divergent smallvec feature lists).
- `pyproject.toml` declares `dynamic = ["version"]`; maturin reads `src-python/Cargo.toml` (its `manifest-path`), which inherits the workspace version — verified that `maturin develop` installs the wheel with the correct version.
- The release procedure's three-file version bump (sections 3.1-3.4) collapses to one `[workspace.package]` edit plus a `cargo metadata` consistency check; all downstream references (final sanity check, commit staging list, troubleshooting, checklists, quick reference) updated to match. The bump step now also refreshes the committed `Cargo.lock`.
- `lint.yml`'s MSRV extraction (`sed -n 's/^rust-version = ...'`) still matches the single `rust-version` line, now in `[workspace.package]`, so no workflow change is needed.

Bead: bd-yfe6.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)