### PR TITLE
Gate the BIBFRAME/RDF stack behind a default-on cargo feature

### DIFF
--- a/.cargo/check.sh
+++ b/.cargo/check.sh
@@ -91,6 +91,12 @@ if [ "$QUICK" = false ]; then
     cargo audit
 
     echo ""
+    echo "=== Feature gate check (no default features) ==="
+    # The bibframe feature is default-on; verify the crate still compiles
+    # with it off (targets needing it declare required-features and skip).
+    cargo check --package mrrc --no-default-features --all-targets --quiet
+
+    echo ""
     echo "=== Unused dependency check ==="
     # Fix with: cargo install cargo-machete --locked
     command -v cargo-machete &> /dev/null \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The version is now declared once, in `[workspace.package]`: both crates inherit it and
   `pyproject.toml` reads it via `dynamic = ["version"]`. Shared dependencies and
   `rust-version` are also workspace-inherited, so they cannot drift between crates.
+- BIBFRAME/RDF support is now behind the default-on `bibframe` cargo feature. Default
+  builds and the Python wheel are unchanged; `--no-default-features` drops the
+  oxrdf/oxrdfio dependency tree for MARC-only users.
 - Record parsing no longer copies every record's bytes into the error-diagnostics
   buffer: the parse buffer is shared by refcount instead, deleting a per-record
   alloc+memcpy that every read path paid so that the under-1% of records that error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,7 @@ harness = false
 [[bench]]
 name = "format_benchmarks"
 harness = false
+required-features = ["bibframe"]
 
 # Release profile for a performance-marketed PyO3 extension: LTO and a
 # single codegen unit make cross-crate inlining deterministic (no more

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,10 @@ constructible_struct_adds_field = "allow"
 function_parameter_count_changed = "allow"
 
 [features]
-default = []
+default = ["bibframe"]
+# BIBFRAME linked-data conversion (the `bibframe` module). On by default;
+# build with --no-default-features to drop the oxrdf/oxrdfio dependency tree.
+bibframe = ["dep:oxrdf", "dep:oxrdfio"]
 
 [dependencies]
 # Core parsing and data handling
@@ -90,9 +93,9 @@ smallvec = { workspace = true }
 rayon = "1.7"
 crossbeam-channel = "0.5"
 
-# RDF serialization for BIBFRAME support
-oxrdfio = "0.2"
-oxrdf = "0.3"
+# RDF serialization for BIBFRAME support (the `bibframe` feature)
+oxrdfio = { version = "0.2", optional = true }
+oxrdf = { version = "0.3", optional = true }
 
 [dev-dependencies]
 proptest = "1.0"
@@ -122,6 +125,40 @@ module_name_repetitions = "allow"
 similar_names = "allow"
 # Type complexity is managed separately
 type_complexity = "allow"
+
+# Targets that exercise the BIBFRAME module are skipped when the
+# `bibframe` feature is off (e.g. the --no-default-features check).
+[[example]]
+name = "marc_to_bibframe"
+required-features = ["bibframe"]
+
+[[example]]
+name = "bibframe_to_marc"
+required-features = ["bibframe"]
+
+[[example]]
+name = "bibframe_batch"
+required-features = ["bibframe"]
+
+[[test]]
+name = "bibframe_unit_tests"
+required-features = ["bibframe"]
+
+[[test]]
+name = "bibframe_integration_tests"
+required-features = ["bibframe"]
+
+[[test]]
+name = "bibframe_validation_tests"
+required-features = ["bibframe"]
+
+[[test]]
+name = "bibframe_roundtrip_tests"
+required-features = ["bibframe"]
+
+[[test]]
+name = "bibframe_baseline_comparison"
+required-features = ["bibframe"]
 
 [[bench]]
 name = "marc_benchmarks"

--- a/src-python/Cargo.toml
+++ b/src-python/Cargo.toml
@@ -10,7 +10,9 @@ repository.workspace = true
 
 [dependencies]
 pyo3 = { version = "0.29", features = ["extension-module"] }
-mrrc = { path = ".." }
+# Enable bibframe explicitly (independent of mrrc's default features)
+# so the wheel always ships full functionality.
+mrrc = { path = "..", features = ["bibframe"] }
 serde_json = { workspace = true }
 # SmallVec for buffered reader: we own the bytes here to safely cross the GIL boundary.
 # Typical MARC records (100B-5KB) fit in 4KB inline buffer without allocation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //! - [`reader`] — Reading MARC records from binary data streams
 //! - [`writer`] — Writing MARC records to binary format
 //! - [`formats`] — Format traits and ISO 2709 support
-//! - [`bibframe`] — BIBFRAME linked data conversion
+//! - [`bibframe`] — BIBFRAME linked data conversion (cargo feature `bibframe`, on by default)
 //! - [`boundary_scanner`] — Record boundary detection for parallel processing
 //! - [`leader`] — MARC record leader (24-byte header)
 //! - [`json`] — JSON serialization/deserialization
@@ -107,6 +107,7 @@ pub mod authority_queries;
 pub mod authority_reader;
 pub mod authority_record;
 pub mod authority_writer;
+#[cfg(feature = "bibframe")]
 pub mod bibframe;
 pub mod bibliographic_helpers;
 pub mod boundary_scanner;


### PR DESCRIPTION
## Summary

- New `bibframe = ["dep:oxrdf", "dep:oxrdfio"]` cargo feature, included in `default`, so default builds see zero behavior change; `--no-default-features` drops the oxrdf/oxrdfio tree (the only notable duplicate dependency, quick-xml 0.37 via oxrdfxml, and the RUSTSEC-2026-0097 rand path).
- `src/bibframe/` is cfg-gated at the single `pub mod` declaration (the module has no top-level re-exports, so that one gate covers the API surface).
- The bindings crate enables the feature explicitly (`features = ["bibframe"]`), independent of mrrc's defaults, so the wheel always ships full functionality.
- The three BIBFRAME examples and five BIBFRAME integration-test targets declare `required-features = ["bibframe"]` in Cargo.toml (no test-file edits), so they are skipped rather than broken when the feature is off.
- check.sh gains a `cargo check --package mrrc --no-default-features --all-targets` step. The bead also asks for a `--no-default-features` CI check; `.github/workflows/` belongs to another track in this parallel-track split, so the workflow addition is left to the coordinator — the check.sh step provides the same compile gate locally.

Bead: bd-yfe6.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)