### PR TITLE
Least-privilege workflow permissions; SHA-pin release-path actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,6 +30,9 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/benchmark-python.yml
+++ b/.github/workflows/benchmark-python.yml
@@ -20,6 +20,9 @@ on:
       - '.gitignore'
       - '.beads/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,6 +15,9 @@ on:
       - 'CHANGELOG.md'
       - 'scripts/lint-changelog.sh'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,9 @@ on:
     - cron: '0 4 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,6 +25,9 @@ on:
         required: false
         default: '300'
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,9 @@ on:
       - '.gitignore'
       - '.beads/**'
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
 

--- a/.github/workflows/memory-safety.yml
+++ b/.github/workflows/memory-safety.yml
@@ -8,6 +8,9 @@ on:
   # Allow manual trigger for on-demand testing
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 6 * * *'  # daily at 6am UTC
   workflow_dispatch:       # allow manual trigger
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -20,6 +20,9 @@ on:
       - '.gitignore'
       - '.beads/**'
 
+permissions:
+  contents: read
+
 env:
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -19,6 +19,9 @@ on:
           - testpypi
         default: none
 
+permissions:
+  contents: read
+
 jobs:
   build-release-wheels:
     name: Build release wheels on ${{ matrix.os }}
@@ -29,13 +32,13 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           manylinux: auto
           # macOS builds universal2 (arm64 + x86_64 in one wheel) so Intel
@@ -46,7 +49,7 @@ jobs:
           args: --release --out dist -i python${{ matrix.python-version }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-wheels-${{ matrix.os }}-${{ matrix.python-version }}
           path: dist
@@ -60,20 +63,20 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
           manylinux: auto
           args: --release --out dist -i python${{ matrix.python-version }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-wheels-${{ matrix.target }}-${{ matrix.python-version }}
           path: dist
@@ -82,15 +85,15 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: sdist
           args: --out dist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-sdist
           path: dist
@@ -100,13 +103,13 @@ jobs:
     needs: build-sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-sdist
           path: dist
@@ -138,7 +141,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-wheels-${{ matrix.target }}-${{ matrix.python-version }}
           path: dist
@@ -177,16 +180,16 @@ jobs:
         target: [aarch64-unknown-linux-gnu, i686-unknown-linux-gnu]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-wheels-${{ matrix.target }}-3.12
           path: dist
 
       - name: Set up QEMU (aarch64 emulation)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Write import-smoke script
         run: |
@@ -228,16 +231,16 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-wheels-${{ matrix.os }}-${{ matrix.python-version }}
           path: dist
@@ -288,7 +291,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # Collects release-wheels-* and release-sdist.
           pattern: release-*
@@ -303,13 +306,13 @@ jobs:
         # skip-existing makes re-runs after a partial failure upload only
         # the missing files instead of dying on "file already exists".
         if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true
 
       - name: Publish to TestPyPI (rehearsal)
         if: github.event_name == 'workflow_dispatch' && inputs.publish-target == 'testpypi'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -324,12 +327,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           sparse-checkout: CHANGELOG.md
           sparse-checkout-cone-mode: false
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # Collects release-wheels-* and release-sdist.
           pattern: release-*
@@ -345,7 +348,7 @@ jobs:
           echo "$NOTES" > release_notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: dist/*
           body_path: release_notes.md

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -8,6 +8,9 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ on:
       - '.gitignore'
       - '.beads/**'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
10 of the 15 workflows inherited the default GITHUB_TOKEN scope, and the OIDC publish job pinned pypa/gh-action-pypi-publish to a moving branch (release/v1) — the highest-value pinning target.

- Every workflow now declares a top-level `permissions:` block; the baseline is `contents: read`, with elevation kept job-scoped where it already existed (publish `id-token: write`, release `contents: write`, failure-notify `issues: write`, docs deploy `pages`/`id-token`).
- python-release.yml pins every action to a full commit SHA with a trailing version comment (checkout v6.0.3, setup-python v6.2.0, maturin-action v1.51.0, upload-artifact v7.0.1, download-artifact v8.0.1, setup-uv v8.1.0, setup-qemu-action v3.7.0, gh-action-pypi-publish v1.14.0, action-gh-release v3.0.0). Dependabot's existing github-actions ecosystem entry keeps SHA pins current. Other workflows stay on tag refs per the bead.
- Repo default workflow token permission verified read-only via the API (`default_workflow_permissions: read`); no settings change needed.

Not applied here: adding required status checks to the `main` ruleset. Two blockers make that a follow-up decision rather than part of this PR: (1) the candidate check names are changing in this PR stack (Test Suite gains an OS matrix, the wheel gate gains smoke jobs), and open PRs from branches without those jobs would become unmergeable the moment the rule lands; (2) test.yml, lint.yml, and python-build.yml all carry `paths-ignore` for docs/markdown, so a docs-only PR triggers none of the candidate checks and would be blocked indefinitely. Requiring checks therefore also means deciding whether to drop `paths-ignore` from the required workflows or to require only always-running checks. The ruleset itself currently has only `deletion` and `non_fast_forward` rules (ruleset id 12658386).

Bead: bd-oayg.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)