### PR TITLE
CI consistency: release env parity, cache unification, per-test retries, type-check gate, timeouts

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -59,6 +59,7 @@ jobs:
     needs: security-audit
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,13 +32,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+        uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -116,6 +110,7 @@ jobs:
     needs: [coverage-rust, coverage-python]
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6.0.3
 
@@ -50,6 +51,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 10
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -112,6 +112,7 @@ jobs:
     needs: fuzz
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -138,6 +138,41 @@ jobs:
       - name: Run stubtest
         run: uv run python -m mypy.stubtest mrrc._mrrc
 
+  typecheck:
+    name: Type check (mypy + pyright on mrrc/)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Sync dev dependencies
+        run: uv sync --extra dev
+
+      - name: Build extension
+        run: uv run maturin develop
+
+      # Same commands as check.sh: both checkers gate the wrapper package
+      # in CI exactly as they do locally.
+      - name: Run mypy on mrrc/
+        run: uv run mypy mrrc/
+
+      - name: Run pyright on mrrc/
+        run: uv run pyright mrrc/
+
   msrv:
     name: MSRV check
     runs-on: ubuntu-latest

--- a/.github/workflows/memory-safety.yml
+++ b/.github/workflows/memory-safety.yml
@@ -19,6 +19,7 @@ jobs:
   asan-library-tests:
     name: ASAN Memory Safety Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       # Let all ASAN tests run even if one fails, for comprehensive feedback
       fail-fast: false
@@ -31,13 +32,7 @@ jobs:
           components: rust-src
 
       - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-asan-${{ hashFiles('**/Cargo.lock') }}
+        uses: Swatinem/rust-cache@v2
 
       - name: Run ASAN on library and integration tests
         env:
@@ -60,6 +55,7 @@ jobs:
     needs: asan-library-tests
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -15,6 +15,7 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6.0.3
 
@@ -23,13 +24,7 @@ jobs:
           components: miri
 
       - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
+        uses: Swatinem/rust-cache@v2
 
       - name: Run Miri on unit tests
         run: cargo +nightly miri test --lib
@@ -44,6 +39,7 @@ jobs:
     needs: miri
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -53,6 +53,9 @@ jobs:
 
       - uses: PyO3/maturin-action@v1
         with:
+          # Compiler cache backed by the GitHub Actions cache: wheel builds
+          # otherwise compile cold on every run.
+          sccache: "true"
           manylinux: off
           args: --release --out dist -i python3.12
 
@@ -90,7 +93,7 @@ jobs:
           # from pyproject.toml so test deps stay in sync with the package
           # and the pymarc parity oracle executes instead of skipping.
           WHEEL=$(ls dist/*.whl | head -1)
-          uv pip install --system "${WHEEL}[test,oracle]"
+          uv pip install --system "${WHEEL}[test,oracle]" pytest-rerunfailures
 
       - name: Verify the pymarc oracle is installed
         shell: bash
@@ -137,6 +140,9 @@ jobs:
 
       - uses: PyO3/maturin-action@v1
         with:
+          # Compiler cache backed by the GitHub Actions cache: wheel builds
+          # otherwise compile cold on every run.
+          sccache: "true"
           manylinux: off
           args: --release --out dist -i python${{ matrix.python-version }}
 
@@ -186,7 +192,7 @@ jobs:
           # from pyproject.toml so test deps stay in sync with the package
           # and the pymarc parity oracle executes instead of skipping.
           WHEEL=$(ls dist/*.whl | head -1)
-          uv pip install --system "${WHEEL}[test,oracle]"
+          uv pip install --system "${WHEEL}[test,oracle]" pytest-rerunfailures
 
       - name: Verify the pymarc oracle is installed
         shell: bash
@@ -197,30 +203,12 @@ jobs:
           python -c "import pymarc, importlib.metadata as m; print('pymarc', m.version('pymarc'))"
 
       - name: Run pytest (core tests, excludes benchmarks)
-        run: |
-          pytest tests/python/ -m "not benchmark" -v
-        # Retry on macOS due to intermittent runner flakiness
-        # See: mrrc-vxmp - tests pass but job occasionally fails
-        if: runner.os != 'macOS'
-
-      - name: Run pytest with retry (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts"
-            if pytest tests/python/ -m "not benchmark" -v; then
-              echo "Tests passed on attempt $attempt"
-              exit 0
-            fi
-            echo "Attempt $attempt failed, retrying..."
-            attempt=$((attempt + 1))
-            sleep 5
-          done
-          echo "All $max_attempts attempts failed"
-          exit 1
         shell: bash
+        env:
+          # Per-test reruns absorb intermittent macOS runner flakiness
+          # with per-test signal instead of rerunning the whole suite.
+          RERUN_FLAGS: ${{ runner.os == 'macOS' && '--reruns 2 --reruns-delay 5' || '' }}
+        run: pytest tests/python/ -m "not benchmark" -v $RERUN_FLAGS
 
   # Full matrix on push to main: os {ubuntu, macos, windows} x
   # python {3.10..3.14}. 15 build + 15 test = 30 jobs.
@@ -247,6 +235,9 @@ jobs:
 
       - uses: PyO3/maturin-action@v1
         with:
+          # Compiler cache backed by the GitHub Actions cache: wheel builds
+          # otherwise compile cold on every run.
+          sccache: "true"
           manylinux: off
           args: --release --out dist -i python${{ matrix.python-version }}
 
@@ -289,7 +280,7 @@ jobs:
           # from pyproject.toml so test deps stay in sync with the package
           # and the pymarc parity oracle executes instead of skipping.
           WHEEL=$(ls dist/*.whl | head -1)
-          uv pip install --system "${WHEEL}[test,oracle]"
+          uv pip install --system "${WHEEL}[test,oracle]" pytest-rerunfailures
 
       - name: Verify the pymarc oracle is installed
         shell: bash
@@ -300,27 +291,9 @@ jobs:
           python -c "import pymarc, importlib.metadata as m; print('pymarc', m.version('pymarc'))"
 
       - name: Run pytest (core tests, excludes benchmarks)
-        run: |
-          pytest tests/python/ -m "not benchmark" -v
-        # Retry on macOS due to intermittent runner flakiness
-        # See: mrrc-vxmp - tests pass but job occasionally fails
-        if: runner.os != 'macOS'
-
-      - name: Run pytest with retry (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts"
-            if pytest tests/python/ -m "not benchmark" -v; then
-              echo "Tests passed on attempt $attempt"
-              exit 0
-            fi
-            echo "Attempt $attempt failed, retrying..."
-            attempt=$((attempt + 1))
-            sleep 5
-          done
-          echo "All $max_attempts attempts failed"
-          exit 1
         shell: bash
+        env:
+          # Per-test reruns absorb intermittent macOS runner flakiness
+          # with per-test signal instead of rerunning the whole suite.
+          RERUN_FLAGS: ${{ runner.os == 'macOS' && '--reruns 2 --reruns-delay 5' || '' }}
+        run: pytest tests/python/ -m "not benchmark" -v $RERUN_FLAGS

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -22,10 +22,17 @@ on:
 permissions:
   contents: read
 
+env:
+  # Same setting as the PR wheel gate and check.sh: build under the
+  # abi3 forward-compatibility flag so a CPython newer than the pinned
+  # pyo3 supports fails here the same way it would fail there.
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
 jobs:
   build-release-wheels:
     name: Build release wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2025]
@@ -57,6 +64,7 @@ jobs:
   build-cross-linux-wheels:
     name: Build cross-compiled ${{ matrix.target }} wheel (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       matrix:
         target: [aarch64-unknown-linux-gnu, i686-unknown-linux-gnu]
@@ -84,6 +92,7 @@ jobs:
   build-sdist:
     name: Build sdist
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -102,6 +111,7 @@ jobs:
     name: Test install from sdist
     needs: build-sdist
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -135,6 +145,7 @@ jobs:
     name: Validate ${{ matrix.target }} wheel (Python ${{ matrix.python-version }})
     needs: build-cross-linux-wheels
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         target: [aarch64-unknown-linux-gnu, i686-unknown-linux-gnu]
@@ -175,6 +186,8 @@ jobs:
     name: Import-smoke ${{ matrix.target }} wheel (Python 3.12)
     needs: build-cross-linux-wheels
     runs-on: ubuntu-latest
+    # QEMU emulation makes the aarch64 leg slow; the budget covers it.
+    timeout-minutes: 30
     strategy:
       matrix:
         target: [aarch64-unknown-linux-gnu, i686-unknown-linux-gnu]
@@ -225,6 +238,7 @@ jobs:
     name: Test release wheels on ${{ matrix.os }}
     needs: build-release-wheels
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2025]
@@ -252,32 +266,15 @@ jobs:
           # [test] via self-reference) so test runtime deps + type checkers
           # stay in sync with pyproject.toml as a single source of truth.
           WHEEL=$(ls dist/mrrc-*.whl | head -1)
-          uv pip install --system "${WHEEL}[dev]"
+          uv pip install --system "${WHEEL}[dev]" pytest-rerunfailures
 
       - name: Run pytest (core tests, excludes benchmarks)
-        run: |
-          pytest tests/python/ -m "not benchmark" -v
-        # Retry on macOS due to intermittent runner flakiness
-        if: runner.os != 'macOS'
-
-      - name: Run pytest with retry (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          max_attempts=3
-          attempt=1
-          while [ $attempt -le $max_attempts ]; do
-            echo "Attempt $attempt of $max_attempts"
-            if pytest tests/python/ -m "not benchmark" -v; then
-              echo "Tests passed on attempt $attempt"
-              exit 0
-            fi
-            echo "Attempt $attempt failed, retrying..."
-            attempt=$((attempt + 1))
-            sleep 5
-          done
-          echo "All $max_attempts attempts failed"
-          exit 1
         shell: bash
+        env:
+          # Per-test reruns absorb intermittent macOS runner flakiness
+          # with per-test signal instead of rerunning the whole suite.
+          RERUN_FLAGS: ${{ runner.os == 'macOS' && '--reruns 2 --reruns-delay 5' || '' }}
+        run: pytest tests/python/ -m "not benchmark" -v $RERUN_FLAGS
 
       - name: Run type checking
         run: |
@@ -288,6 +285,7 @@ jobs:
     name: Publish to PyPI
     needs: [test-release-wheels, validate-cross-wheels, smoke-test-cross-wheels, test-sdist]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write
     steps:
@@ -324,6 +322,7 @@ jobs:
     needs: publish-pypi
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
A set of consistency fixes across the workflows:

- Release env parity: python-release.yml now sets PYO3_USE_ABI3_FORWARD_COMPATIBILITY like the PR wheel gate and check.sh, so a CPython newer than the pinned pyo3 supports fails in regular CI rather than for the first time at release.
- Cache unification: coverage, miri, and memory-safety drop their raw actions/cache blocks (keyed only on Cargo.lock) for Swatinem/rust-cache, matching lint.yml/test.yml; fuzz.yml keeps its raw cache because it covers the separate fuzz/ workspace target dir. python-build.yml's three maturin build steps enable sccache (GitHub Actions cache backend), so PR wheel builds stop compiling cold — that job bounds the PR gate's wall time.
- Retries: the 18-line macOS whole-suite retry loop, copy-pasted in test-wheels-pr, test-wheels-main, and test-release-wheels, is replaced by pytest-rerunfailures with `--reruns 2 --reruns-delay 5` applied only when the runner is macOS — per-test retries with per-test signal. pytest-rerunfailures installs alongside the wheel in those jobs rather than via a pyproject extra, keeping pyproject untouched.
- Type-check gating: lint.yml gains a typecheck job running `uv run mypy mrrc/` and `uv run pyright mrrc/` — the same commands check.sh runs locally — so wrapper type errors now block in CI.
- Timeouts: every job now has timeout-minutes (miri 60, ASAN 45, docs build/deploy 15/10, all python-release jobs, and 5 for the failure-notify jobs); these previously fell back to the 360-minute default.

Deferred from the bead: item (h), replacing the stale GIL_RELEASE_IMPLEMENTATION_PLAN.md reference in src-python/src/readers.rs — read-path work is active in another session, so no src/ files are touched here.

Bead: bd-oayg.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)