### PR TITLE
Modernize the profiling guide against the current bench set

### DIFF
--- a/docs/contributing/benchmarking.md
+++ b/docs/contributing/benchmarking.md
@@ -4,6 +4,10 @@ mrrc has three permanent benchmark layers. Each catches a different class of
 regression and runs in a different place; the table at the bottom of this
 page summarizes when to reach for which.
 
+These layers measure *how fast* the code is. To find out *where* the time
+goes, see the [Profiling Guide](profiling.md), which covers local CPU
+profiling of the same bench targets with `cargo flamegraph`.
+
 ## Rust criterion benchmarks
 
 Located in `benches/`. Run with `cargo bench --bench <name>`. Output lands

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -1,6 +1,24 @@
 # Profiling Guide
 
-This guide documents how to profile mrrc performance using various tools available in the Rust ecosystem.
+This guide covers local CPU profiling of mrrc with `cargo flamegraph`. It is
+the "where is the time going?" companion to
+[Benchmarking](benchmarking.md), which covers "how fast is it?" measurement
+with criterion, pytest-benchmark, and CodSpeed.
+
+## Where profiling fits in the perf workflow
+
+The benchmark layers tell you *that* something is slow or regressed:
+
+- **criterion** (`cargo bench`) gives local walltime numbers per scenario.
+- **CodSpeed** runs the single-threaded criterion benches in CI under
+  simulation mode and flags PR-vs-main drift. Simulation mode serializes
+  threads, so rayon speedup is only measurable locally — profile and bench
+  `parallel_benchmarks` on your own machine.
+
+A flamegraph tells you *why*: which functions dominate the hot path, and
+where allocations or copies hide. Profile locally when a bench number moves
+and the cause isn't obvious, or before starting optimization work to find
+the real bottleneck.
 
 ## Prerequisites
 
@@ -12,115 +30,141 @@ Install flamegraph for CPU profiling:
 cargo install flamegraph
 ```
 
-**macOS Requirements:**
-- Full Xcode (not just Command Line Tools) - required for `xctrace`
-- If you only have Command Line Tools, flamegraph will fail to sample
+**macOS requirements:**
 
-**Linux Requirements:**
-- `perf` package (usually included with build tools)
-- `perl` for flamegraph script processing
+- Full Xcode (not just Command Line Tools) — `cargo flamegraph` samples via
+  `xctrace`, which ships only with the full Xcode install from the App Store
+  or developer.apple.com.
 
-## CPU Profiling with Flamegraph
+**Linux requirements:**
 
-### Single-threaded Benchmark
+- `perf` (usually packaged as `linux-tools` or `perf`)
+- `perl` for the flamegraph script processing
 
-Profile the `profiling_harness` benchmark (single-threaded file reading):
+### Debug symbols
 
-```bash
-cargo flamegraph --bench profiling_harness -o flamegraphs/profiling_harness.svg
-```
+`Cargo.toml` sets `debug = true` in `[profile.bench]`, so bench builds keep
+the debuginfo flamegraph needs for readable stacks. No extra flags required.
 
-This produces an interactive SVG showing:
-- Time spent in each function
-- Call stack depth
-- Percentage of total runtime per function
+### Fixtures
 
-### Concurrent Benchmark
+The benches read `tests/data/fixtures/` (1k / 5k / 10k record files, checked
+in). See [Benchmarking](benchmarking.md) for regenerating the larger
+gitignored fixtures.
 
-Profile the `parallel_benchmarks` benchmark (rayon-based concurrent reading):
+## CPU profiling with flamegraph
 
-```bash
-cargo flamegraph --bench parallel_benchmarks -o flamegraphs/parallel_benchmarks.svg
-```
+All bench targets are criterion harnesses (`harness = false`). When invoked
+through `cargo flamegraph`, pass `--bench` after `--` so the criterion
+binary runs in benchmark mode, and `--profile-time <secs>` so it loops the
+benchmark for a fixed duration instead of spending samples on criterion's
+statistical analysis. A trailing filter narrows to one scenario.
 
-### Detailed Profiling
+### Single-threaded read path
 
-Profile the `detailed_profiling` benchmark with memory and phase analysis:
-
-```bash
-cargo flamegraph --bench detailed_profiling -o flamegraphs/detailed_profiling.svg
-```
-
-### Custom Flamegraph Options
-
-Generate flamegraph with full call stacks and all events:
+`marc_benchmarks` covers the core ISO 2709 read, field-access, and
+JSON/XML serialization paths:
 
 ```bash
-cargo flamegraph --bench profiling_harness -- --verbose \
-  -o flamegraphs/profiling_harness_verbose.svg
+cargo flamegraph --bench marc_benchmarks -o flamegraphs/read_1k.svg \
+  -- --bench --profile-time 10 read_1k_records
 ```
 
-Frequency (sampling rate in Hz, default 99):
+Other useful scenario filters: `read_10k_records`, `read_1k_records_from_path`,
+`read_1k_with_field_access`, `serialize_1k_to_json`, `serialize_1k_to_xml`,
+`roundtrip_1k_records`.
+
+### Concurrent read path
+
+`parallel_benchmarks` covers rayon-based concurrent reading against
+sequential baselines:
 
 ```bash
-cargo flamegraph --bench profiling_harness -- -F 1000 \
-  -o flamegraphs/profiling_harness_1khz.svg
+cargo flamegraph --bench parallel_benchmarks -o flamegraphs/parallel_4x.svg \
+  -- --bench --profile-time 10 parallel_4x_1k_records
 ```
 
-## Interpreting Flamegraphs
+### Format conversion paths
+
+`format_benchmarks` covers CSV, MARC-in-JSON, MODS, Dublin Core, and
+BIBFRAME serialization plus the parser-pool path:
+
+```bash
+cargo flamegraph --bench format_benchmarks -o flamegraphs/formats.svg \
+  -- --bench --profile-time 10
+```
+
+### Error-handling overhead
+
+`error_handling_benchmarks` compares strict and lenient parsing of clean
+versus malformed input:
+
+```bash
+cargo flamegraph --bench error_handling_benchmarks -o flamegraphs/errors.svg \
+  -- --bench --profile-time 10
+```
+
+### Sampling frequency
+
+The default sampling rate is 99 Hz. For short hot paths, raise it with
+flamegraph's `--freq` flag (before the `--`):
+
+```bash
+cargo flamegraph --freq 1000 --bench marc_benchmarks \
+  -o flamegraphs/read_1k_1khz.svg -- --bench --profile-time 10 read_1k_records
+```
+
+## Interpreting flamegraphs
 
 1. **Width** = time spent in function (wider = more time)
 2. **Height** = call stack depth (taller = deeper nesting)
 3. **Color** = random (for visual distinction)
-4. **X-axis** = execution order
+4. **X-axis** = alphabetical merge order, not time
 5. **Y-axis** = call stack
 
-### Common Patterns to Look For
+### Common patterns to look for
 
 - **Flat top** = pure computation or tight loop
 - **Sawtooth pattern** = recursive calls or repeated function sequences
 - **Thin slices** = low-overhead functions called many times
 - **Wide base** = time spent in main execution path
 
-## Quick Profiling Checklist
+## Optimization checklist
 
-For performance optimization work:
+Hard-won rules from past mrrc profiling work:
 
-```bash
-# Build debug symbols (required for flamegraph on release builds)
-# Already configured in Cargo.toml [profile.bench] section
-
-# Profile single-threaded baseline
-cargo flamegraph --bench profiling_harness -o /tmp/single.svg
-
-# Profile concurrent implementation
-cargo flamegraph --bench parallel_benchmarks -o /tmp/concurrent.svg
-
-# Compare outputs in browser:
-# - Wider functions = optimization opportunities
-# - Identify bottlenecks not visible in benchmarks
-```
-
-## Integration with CI/CD
-
-Flamegraphs can be:
-- Committed to git (`flamegraphs/` directory)
-- Uploaded to artifact storage
-- Compared across releases for regression detection
+1. **Measure before optimizing.** Architectural changes that aren't on the
+   critical path produce zero improvement; a flamegraph confirms the change
+   targets where time actually goes.
+2. **Allocations on the hot path are the usual culprit.** The biggest past
+   wins came from eliminating per-record `String` and `Vec` allocations in
+   frequently-called parse functions, not from clever restructuring.
+3. **Find *where* allocations happen, not just how many.** The call stack
+   matters: one allocation in a per-record loop outweighs many in setup code.
+4. **Re-bench after every change.** Small incremental optimizations with
+   direct criterion measurement beat large speculative refactors. Compare
+   `cargo bench` output before and after each commit.
 
 ## Troubleshooting
 
 ### macOS: "tool 'xctrace' requires Xcode"
-- Install full Xcode: `xcode-select --install` (installs Command Line Tools)
-- Full Xcode required: Download from App Store or developer.apple.com
 
-### Linux: "perf not found"
+Command Line Tools alone are not enough — install the full Xcode from the
+App Store or developer.apple.com, then point the tools at it:
+
 ```bash
-sudo apt-get install linux-tools  # Debian/Ubuntu
-sudo yum install perf              # RHEL/Fedora
+sudo xcode-select -s /Applications/Xcode.app
 ```
 
-### Flamegraph output empty
-- Ensure binary is running long enough to collect samples
-- Increase bench duration or iterations
-- Use `-F` flag to increase sampling frequency
+### Linux: "perf not found"
+
+```bash
+sudo apt-get install linux-tools-common linux-tools-generic  # Debian/Ubuntu
+sudo dnf install perf                                        # Fedora/RHEL
+```
+
+### Flamegraph output empty or sparse
+
+- Ensure the run is long enough to collect samples — raise `--profile-time`
+- Increase sampling frequency with `--freq`
+- Confirm the scenario filter matches a bench name (no match = instant exit)


### PR DESCRIPTION
The profiling guide salvaged in PR #260 still described the 2026-02 bench layout: it named `profiling_harness` and `detailed_profiling` (both deleted) and read as a standalone process with no connection to the criterion / CodSpeed measurement workflow.

This PR rewrites `docs/contributing/profiling.md` so that:

- Every flamegraph command targets a bench that exists (`marc_benchmarks`, `parallel_benchmarks`, `format_benchmarks`, `error_handling_benchmarks`) and the invocations are verified to run (`-- --bench --profile-time <secs>` plus scenario filters, with working filter names listed).
- A "where profiling fits" section positions local flamegraphs next to criterion walltime numbers and CodSpeed simulation mode, including the note that simulation mode serializes threads so rayon speedup is only measurable locally.
- The reusable lessons from the archived `docs/history/profiling/SINGLE_THREADED_BOTTLENECK_ANALYSIS_2026.md` are distilled into a short optimization checklist (measure first, hunt hot-path allocations, locate allocations by call stack, re-bench every change) instead of keeping the dated report live.
- The macOS/Linux troubleshooting steps are corrected (`xcode-select --install` does not install full Xcode; updated package names for perf).
- `docs/contributing/benchmarking.md` and the profiling guide now cross-link each other, so contributors land on the right page for "how fast" versus "where does the time go".

`mkdocs build` stays warning-free and `.cargo/check.sh` passes.

Bead: bd-l9zh.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)