### PR TITLE
Consolidate per-variant MarcError accessors behind a single metadata() table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a new `oracle` extra pins pymarc in uv.lock (Dependabot adjudicates behavior changes on
   bump PRs), and the oracle extends beyond iteration shape to value-level comparisons —
   title, `format_field()`, `value()`, and `as_marc()` byte-equality over the 1k corpus.
+- `MarcError::metadata()` returns an `ErrorMetadata` snapshot of every structured field an
+  error carries. The per-field accessors, `Display`/`detailed()` rendering, JSON output, and
+  the Python exception mapping all read from this single per-variant table now; rendered and
+  serialized output is unchanged.
 
 ### Changed
 

--- a/mrrc/exceptions.py
+++ b/mrrc/exceptions.py
@@ -144,8 +144,18 @@ class _MrrcExceptionBase(_MixinBase):
     bytes_near: Optional[bytes]
     bytes_near_offset: Optional[int]
 
+    # Per-subclass extra keyword arguments beyond _POSITIONAL_FIELDS,
+    # declared once per class (e.g., ``("message",)`` or
+    # ``("expected_length", "actual_length")``). This single table drives
+    # __init__ kwarg handling, pickle round-trips, and to_dict() output, so
+    # a new exception class only declares its extras here — no per-class
+    # __init__ / pickle / serialization overrides.
+    _extra_fields: tuple = ()
+
     def __init__(self, *args, **kwargs) -> None:
         for field in _POSITIONAL_FIELDS:
+            setattr(self, field, kwargs.pop(field, None))
+        for field in self._extra_fields:
             setattr(self, field, kwargs.pop(field, None))
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
@@ -162,11 +172,6 @@ class _MrrcExceptionBase(_MixinBase):
     # tuple, dropping instance __dict__. Override __reduce__ so kwargs
     # survive a pickle round-trip.
 
-    # Per-subclass extra attributes that should be preserved across pickle
-    # round-trips in addition to _POSITIONAL_FIELDS. Subclasses with extra
-    # __init__ kwargs (e.g., InvalidField.message) override this.
-    _pickle_extra_fields: tuple = ()
-
     def __reduce__(self):
         return (self.__class__, (), self._pickle_state())
 
@@ -176,7 +181,7 @@ class _MrrcExceptionBase(_MixinBase):
         # (including __dict__ or method names) and shadow class methods on
         # the instance — pickle deserialization itself is the RCE primitive,
         # but blind setattr amplifies the blast radius unnecessarily.
-        allowed = set(_POSITIONAL_FIELDS) | set(self._pickle_extra_fields)
+        allowed = set(_POSITIONAL_FIELDS) | set(self._extra_fields)
         unexpected = set(state) - allowed
         if unexpected:
             raise TypeError(
@@ -188,7 +193,7 @@ class _MrrcExceptionBase(_MixinBase):
 
     def _pickle_state(self) -> dict:
         state = {f: getattr(self, f) for f in _POSITIONAL_FIELDS}
-        for f in self._pickle_extra_fields:
+        for f in self._extra_fields:
             state[f] = getattr(self, f, None)
         return state
 
@@ -323,11 +328,6 @@ class _MrrcExceptionBase(_MixinBase):
 
     SCHEMA_VERSION: int = 1
 
-    # Per-subclass extra fields to include in to_dict() output beyond the
-    # base _POSITIONAL_FIELDS. Subclasses with extras like `message` or
-    # `expected_length` declare them here.
-    _diagnostic_extra_fields: tuple = ()
-
     def to_dict(self, *, include_traceback: bool = False) -> dict:
         """Render this exception as a JSON-ready dict.
 
@@ -358,7 +358,7 @@ class _MrrcExceptionBase(_MixinBase):
                 result[field] = None
             else:
                 result[field] = value
-        for field in self._diagnostic_extra_fields:
+        for field in self._extra_fields:
             value = getattr(self, field, None)
             if isinstance(value, bytes):
                 result[f"{field}_hex"] = value.hex()
@@ -408,13 +408,8 @@ class RecordLeaderInvalid(MrrcException):
 
     code = "E002"
     slug = "leader_invalid"
-    _pickle_extra_fields = ("message",)
-    _diagnostic_extra_fields = ("message",)
+    _extra_fields = ("message",)
     message: Optional[str]
-
-    def __init__(self, *args, message=None, **kwargs) -> None:
-        self.message = message
-        super().__init__(*args, **kwargs)
 
     def _body_text(self) -> str:
         if self.message:
@@ -500,15 +495,9 @@ class FatalReaderError(MrrcException):
 
     code = "E099"
     slug = "fatal_reader_error"
-    _pickle_extra_fields = ("cap", "errors_seen")
-    _diagnostic_extra_fields = ("cap", "errors_seen")
+    _extra_fields = ("cap", "errors_seen")
     cap: Optional[int]
     errors_seen: Optional[int]
-
-    def __init__(self, *args, cap=None, errors_seen=None, **kwargs) -> None:
-        self.cap = cap
-        self.errors_seen = errors_seen
-        super().__init__(*args, **kwargs)
 
     def _body_text(self) -> str:
         if self.cap is not None and self.errors_seen is not None:
@@ -551,13 +540,8 @@ class InvalidField(RecordDirectoryInvalid):
 
     code = "E106"
     slug = "invalid_field"
-    _pickle_extra_fields = ("message",)
-    _diagnostic_extra_fields = ("message",)
+    _extra_fields = ("message",)
     message: Optional[str]
-
-    def __init__(self, *args, message=None, **kwargs) -> None:
-        self.message = message
-        super().__init__(*args, **kwargs)
 
     def _body_text(self) -> str:
         if self.message:
@@ -570,15 +554,9 @@ class TruncatedRecord(EndOfRecordNotFound):
 
     code = "E005"
     slug = "truncated_record"
-    _pickle_extra_fields = ("expected_length", "actual_length")
-    _diagnostic_extra_fields = ("expected_length", "actual_length")
+    _extra_fields = ("expected_length", "actual_length")
     expected_length: Optional[int]
     actual_length: Optional[int]
-
-    def __init__(self, *args, expected_length=None, actual_length=None, **kwargs) -> None:
-        self.expected_length = expected_length
-        self.actual_length = actual_length
-        super().__init__(*args, **kwargs)
 
     def _body_text(self) -> str:
         if self.expected_length is not None and self.actual_length is not None:
@@ -604,13 +582,8 @@ class EncodingError(MrrcException):
 
     code = "E301"
     slug = "utf8_invalid"
-    _pickle_extra_fields = ("message",)
-    _diagnostic_extra_fields = ("message",)
+    _extra_fields = ("message",)
     message: Optional[str]
-
-    def __init__(self, *args, message=None, **kwargs) -> None:
-        self.message = message
-        super().__init__(*args, **kwargs)
 
     def _body_text(self) -> str:
         if self.message:
@@ -623,13 +596,8 @@ class XmlError(MrrcException):
 
     code = "E401"
     slug = "marcxml_invalid"
-    _pickle_extra_fields = ("message",)
-    _diagnostic_extra_fields = ("message",)
+    _extra_fields = ("message",)
     message: Optional[str]
-
-    def __init__(self, *args, message=None, **kwargs) -> None:
-        self.message = message
-        super().__init__(*args, **kwargs)
 
     def _body_text(self) -> str:
         if self.message:
@@ -642,13 +610,8 @@ class JsonError(MrrcException):
 
     code = "E402"
     slug = "marcjson_invalid"
-    _pickle_extra_fields = ("message",)
-    _diagnostic_extra_fields = ("message",)
+    _extra_fields = ("message",)
     message: Optional[str]
-
-    def __init__(self, *args, message=None, **kwargs) -> None:
-        self.message = message
-        super().__init__(*args, **kwargs)
 
     def _body_text(self) -> str:
         if self.message:
@@ -661,13 +624,8 @@ class WriterError(MrrcException):
 
     code = "E404"
     slug = "record_too_large_for_iso2709"
-    _pickle_extra_fields = ("message",)
-    _diagnostic_extra_fields = ("message",)
+    _extra_fields = ("message",)
     message: Optional[str]
-
-    def __init__(self, *args, message=None, **kwargs) -> None:
-        self.message = message
-        super().__init__(*args, **kwargs)
 
     def _body_text(self) -> str:
         if self.message:

--- a/scripts/verify_error_docs.py
+++ b/scripts/verify_error_docs.py
@@ -10,7 +10,7 @@ gap the error_coverage harness can't (a new code with no manifest case).
 It reconciles three sources of truth and fails (exit 1) on any disagreement:
 
   1. `src/error.rs`            — the MarcError variants and their codes
-                                 (the `code()` match arms).
+                                 (the `metadata()` match arms).
   2. `docs/reference/error-codes.md` — the documented error codes.
   3. `tests/error_coverage.toml`     — the per-code coverage manifest.
 
@@ -41,11 +41,19 @@ SRC_DIRS = [REPO / "src", REPO / "src-python" / "src"]
 
 
 def variant_to_code() -> dict[str, str]:
-    """Parse the `MarcError::Variant { .. } => "ENNN"` arms in error.rs."""
+    """Parse the variant-to-code pairs from the `metadata()` arms in error.rs.
+
+    Each arm has the shape `MarcError::Variant { <bindings> } => ErrorMetadata
+    { code: "ENNN", ... }` with `code` as the first field of the struct
+    literal; `[^}]*` spans the binding list (which contains no braces).
+    """
     text = ERROR_RS.read_text(encoding="utf-8")
-    pairs = re.findall(r"MarcError::(\w+)\s*\{\s*\.\.\s*\}\s*=>\s*\"(E\d+)\"", text)
+    pairs = re.findall(
+        r"MarcError::(\w+)\s*\{[^}]*\}\s*=>\s*ErrorMetadata\s*\{\s*code:\s*\"(E\d+)\"",
+        text,
+    )
     if not pairs:
-        sys.exit(f"FATAL: no code() arms parsed from {ERROR_RS}")
+        sys.exit(f"FATAL: no metadata() code arms parsed from {ERROR_RS}")
     return {variant: code for variant, code in pairs}
 
 

--- a/src-python/src/error.rs
+++ b/src-python/src/error.rs
@@ -7,7 +7,7 @@
 // kwargs rejected — the mapping falls back to a bare `PyValueError` with the
 // Rust `Display` output as its message, so an error never gets dropped.
 
-use mrrc::{BytesNear, MarcError};
+use mrrc::MarcError;
 use pyo3::PyErr;
 use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
@@ -69,311 +69,86 @@ fn build_typed<'py>(py: Python<'py>, err: &MarcError) -> PyResult<Bound<'py, PyA
 /// Pull the Python class name and kwargs out of `err`. Note: `IoError`
 /// returns Err so the caller falls through to `PyIOError`, which is the
 /// proper Python class for I/O errors (matches built-in `OSError`).
+///
+/// The positional kwargs (`record_index`, `byte_offset`, `found`, ...) are
+/// driven uniformly from [`MarcError::metadata`] — every mrrc exception
+/// class accepts the full positional set with `None` defaults, so absent
+/// fields simply pass through as `None`. Only the Python class name and the
+/// per-class extra kwargs (`message`, `expected_length`/`actual_length`,
+/// `cap`/`errors_seen` — rejected by classes that don't declare them) need
+/// the per-variant `match`.
 fn describe<'py>(py: Python<'py>, err: &MarcError) -> PyResult<(&'static str, Bound<'py, PyDict>)> {
+    let md = err.metadata();
     let kwargs = PyDict::new(py);
+    kwargs.set_item("record_index", md.record_index)?;
+    kwargs.set_item("record_control_number", md.record_control_number)?;
+    kwargs.set_item("field_tag", md.field_tag)?;
+    kwargs.set_item("source", md.source_name)?;
+    kwargs.set_item("byte_offset", md.byte_offset)?;
+    kwargs.set_item("record_byte_offset", md.record_byte_offset)?;
+    kwargs.set_item("indicator_position", md.indicator_position)?;
+    kwargs.set_item("subfield_code", md.subfield_code)?;
+    kwargs.set_item("expected", md.expected)?;
+    match md.found {
+        Some(bytes) => kwargs.set_item("found", PyBytes::new(py, bytes))?,
+        None => kwargs.set_item("found", py.None())?,
+    }
+    match md.bytes_near {
+        Some(window) => {
+            kwargs.set_item("bytes_near", PyBytes::new(py, &window.bytes))?;
+            kwargs.set_item("bytes_near_offset", window.start_offset)?;
+        },
+        None => {
+            kwargs.set_item("bytes_near", py.None())?;
+            kwargs.set_item("bytes_near_offset", py.None())?;
+        },
+    }
+
     let class_name: &'static str = match err {
-        MarcError::InvalidLeader {
-            record_index,
-            byte_offset,
-            record_byte_offset,
-            source_name,
-            message,
-            bytes_near,
-        } => {
-            populate_common(py, &kwargs, *record_index, None, None, source_name)?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            kwargs.set_item("record_byte_offset", *record_byte_offset)?;
+        MarcError::InvalidLeader { message, .. } => {
             kwargs.set_item("message", message)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
             "RecordLeaderInvalid"
         },
-        MarcError::RecordLengthInvalid {
-            record_index,
-            byte_offset,
-            source_name,
-            found,
-            expected,
-            bytes_near,
-        } => {
-            populate_common(py, &kwargs, *record_index, None, None, source_name)?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            set_found(py, &kwargs, found.as_deref())?;
-            kwargs.set_item("expected", expected)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
-            "RecordLengthInvalid"
-        },
-        MarcError::BaseAddressInvalid {
-            record_index,
-            byte_offset,
-            source_name,
-            record_control_number,
-            found,
-            expected,
-            bytes_near,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                None,
-                source_name,
-            )?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            set_found(py, &kwargs, found.as_deref())?;
-            kwargs.set_item("expected", expected)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
-            "BaseAddressInvalid"
-        },
-        MarcError::BaseAddressNotFound {
-            record_index,
-            byte_offset,
-            source_name,
-            record_control_number,
-            bytes_near,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                None,
-                source_name,
-            )?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
-            "BaseAddressNotFound"
-        },
-        MarcError::DirectoryInvalid {
-            record_index,
-            byte_offset,
-            record_byte_offset,
-            source_name,
-            record_control_number,
-            field_tag,
-            found,
-            expected,
-            bytes_near,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                field_tag.as_deref(),
-                source_name,
-            )?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            kwargs.set_item("record_byte_offset", *record_byte_offset)?;
-            set_found(py, &kwargs, found.as_deref())?;
-            kwargs.set_item("expected", expected)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
-            "RecordDirectoryInvalid"
-        },
+        MarcError::RecordLengthInvalid { .. } => "RecordLengthInvalid",
+        MarcError::BaseAddressInvalid { .. } => "BaseAddressInvalid",
+        MarcError::BaseAddressNotFound { .. } => "BaseAddressNotFound",
+        MarcError::DirectoryInvalid { .. } => "RecordDirectoryInvalid",
         MarcError::TruncatedRecord {
-            record_index,
-            byte_offset,
-            record_byte_offset,
-            source_name,
-            record_control_number,
             expected_length,
             actual_length,
-            bytes_near,
+            ..
         } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                None,
-                source_name,
-            )?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            kwargs.set_item("record_byte_offset", *record_byte_offset)?;
             kwargs.set_item("expected_length", *expected_length)?;
             kwargs.set_item("actual_length", *actual_length)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
             "TruncatedRecord"
         },
-        MarcError::EndOfRecordNotFound {
-            record_index,
-            byte_offset,
-            record_byte_offset,
-            source_name,
-            record_control_number,
-            bytes_near,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                None,
-                source_name,
-            )?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            kwargs.set_item("record_byte_offset", *record_byte_offset)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
-            "EndOfRecordNotFound"
-        },
-        MarcError::InvalidIndicator {
-            record_index,
-            byte_offset,
-            record_byte_offset,
-            source_name,
-            record_control_number,
-            field_tag,
-            indicator_position,
-            found,
-            expected,
-            bytes_near,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                field_tag.as_deref(),
-                source_name,
-            )?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            kwargs.set_item("record_byte_offset", *record_byte_offset)?;
-            kwargs.set_item("indicator_position", *indicator_position)?;
-            set_found(py, &kwargs, found.as_deref())?;
-            kwargs.set_item("expected", expected)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
-            "InvalidIndicator"
-        },
-        MarcError::BadSubfieldCode {
-            record_index,
-            byte_offset,
-            record_byte_offset,
-            source_name,
-            record_control_number,
-            field_tag,
-            subfield_code,
-            bytes_near,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                field_tag.as_deref(),
-                source_name,
-            )?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            kwargs.set_item("record_byte_offset", *record_byte_offset)?;
-            kwargs.set_item("subfield_code", *subfield_code)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
-            "BadSubfieldCode"
-        },
-        MarcError::InvalidField {
-            record_index,
-            byte_offset,
-            record_byte_offset,
-            source_name,
-            record_control_number,
-            field_tag,
-            message,
-            bytes_near,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                field_tag.as_deref(),
-                source_name,
-            )?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
-            kwargs.set_item("record_byte_offset", *record_byte_offset)?;
+        MarcError::EndOfRecordNotFound { .. } => "EndOfRecordNotFound",
+        MarcError::InvalidIndicator { .. } => "InvalidIndicator",
+        MarcError::BadSubfieldCode { .. } => "BadSubfieldCode",
+        MarcError::InvalidField { message, .. } => {
             kwargs.set_item("message", message)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
             "InvalidField"
         },
-        MarcError::EncodingError {
-            record_index,
-            byte_offset,
-            source_name,
-            record_control_number,
-            field_tag,
-            message,
-            bytes_near,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                field_tag.as_deref(),
-                source_name,
-            )?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
+        MarcError::EncodingError { message, .. } => {
             kwargs.set_item("message", message)?;
-            set_bytes_near(py, &kwargs, bytes_near.as_ref())?;
             "EncodingError"
         },
-        MarcError::FieldNotFound {
-            record_index,
-            record_control_number,
-            field_tag,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                Some(field_tag.as_str()),
-                &None,
-            )?;
-            "FieldNotFound"
-        },
-        MarcError::XmlError {
-            cause,
-            record_index,
-            byte_offset,
-            source_name,
-        } => {
-            populate_common(py, &kwargs, *record_index, None, None, source_name)?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
+        MarcError::FieldNotFound { .. } => "FieldNotFound",
+        MarcError::XmlError { cause, .. } => {
             kwargs.set_item("message", cause.to_string())?;
             "XmlError"
         },
-        MarcError::JsonError {
-            cause,
-            record_index,
-            byte_offset,
-            source_name,
-        } => {
-            populate_common(py, &kwargs, *record_index, None, None, source_name)?;
-            kwargs.set_item("byte_offset", *byte_offset)?;
+        MarcError::JsonError { cause, .. } => {
             kwargs.set_item("message", cause.to_string())?;
             "JsonError"
         },
-        MarcError::WriterError {
-            record_index,
-            record_control_number,
-            message,
-        } => {
-            populate_common(
-                py,
-                &kwargs,
-                *record_index,
-                record_control_number.as_deref(),
-                None,
-                &None,
-            )?;
+        MarcError::WriterError { message, .. } => {
             kwargs.set_item("message", message)?;
             "WriterError"
         },
         MarcError::FatalReaderError {
-            cap,
-            errors_seen,
-            record_index,
-            source_name,
+            cap, errors_seen, ..
         } => {
-            populate_common(py, &kwargs, *record_index, None, None, source_name)?;
             kwargs.set_item("cap", *cap)?;
             kwargs.set_item("errors_seen", *errors_seen)?;
             "FatalReaderError"
@@ -385,48 +160,4 @@ fn describe<'py>(py: Python<'py>, err: &MarcError) -> PyResult<(&'static str, Bo
         },
     };
     Ok((class_name, kwargs))
-}
-
-fn populate_common<'py>(
-    _py: Python<'py>,
-    kwargs: &Bound<'py, PyDict>,
-    record_index: Option<usize>,
-    record_control_number: Option<&str>,
-    field_tag: Option<&str>,
-    source_name: &Option<String>,
-) -> PyResult<()> {
-    kwargs.set_item("record_index", record_index)?;
-    kwargs.set_item("record_control_number", record_control_number)?;
-    kwargs.set_item("field_tag", field_tag)?;
-    kwargs.set_item("source", source_name.as_deref())?;
-    Ok(())
-}
-
-fn set_found<'py>(
-    py: Python<'py>,
-    kwargs: &Bound<'py, PyDict>,
-    found: Option<&[u8]>,
-) -> PyResult<()> {
-    match found {
-        Some(bytes) => kwargs.set_item("found", PyBytes::new(py, bytes)),
-        None => kwargs.set_item("found", py.None()),
-    }
-}
-
-fn set_bytes_near<'py>(
-    py: Python<'py>,
-    kwargs: &Bound<'py, PyDict>,
-    bytes_near: Option<&BytesNear>,
-) -> PyResult<()> {
-    match bytes_near {
-        Some(window) => {
-            kwargs.set_item("bytes_near", PyBytes::new(py, &window.bytes))?;
-            kwargs.set_item("bytes_near_offset", window.start_offset)?;
-        },
-        None => {
-            kwargs.set_item("bytes_near", py.None())?;
-            kwargs.set_item("bytes_near_offset", py.None())?;
-        },
-    }
-    Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,72 @@ impl BytesNear {
     }
 }
 
+/// Borrowed snapshot of the structured metadata carried by a [`MarcError`].
+///
+/// Produced by [`MarcError::metadata`] from a single `match` over all
+/// variants. Fields a variant does not carry are `None`; [`Self::code`],
+/// [`Self::slug`], and [`Self::kind`] are always populated. The per-field
+/// accessors on `MarcError` are one-line reads of this struct, so adding an
+/// enum variant only requires a new arm in [`MarcError::metadata`] (plus the
+/// crate-private mutable counterpart) rather than one arm per accessor.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct ErrorMetadata<'a> {
+    /// Stable error code (`E001`–`E4xx`); see [`MarcError::code`].
+    pub code: &'static str,
+    /// Human-friendly slug; see [`MarcError::slug`].
+    pub slug: &'static str,
+    /// Short `PascalCase` variant name (e.g. `"InvalidIndicator"`).
+    pub kind: &'static str,
+    /// 1-based record index in the stream, when known.
+    pub record_index: Option<usize>,
+    /// Absolute byte offset within the stream, when known.
+    pub byte_offset: Option<usize>,
+    /// Byte offset within the current record, when known.
+    pub record_byte_offset: Option<usize>,
+    /// Source filename or stream identifier, when known.
+    pub source_name: Option<&'a str>,
+    /// 001 control number, when known.
+    pub record_control_number: Option<&'a str>,
+    /// Field tag involved, when known.
+    pub field_tag: Option<&'a str>,
+    /// Variant-specific human-readable message, when the variant exposes one
+    /// (`InvalidField`, `EncodingError`, `WriterError`).
+    pub message: Option<&'a str>,
+    /// Indicator position (0 or 1); `InvalidIndicator` only.
+    pub indicator_position: Option<u8>,
+    /// Offending subfield code byte; `BadSubfieldCode` only.
+    pub subfield_code: Option<u8>,
+    /// The bytes that triggered the error, capped at [`FOUND_BYTES_CAP`].
+    pub found: Option<&'a [u8]>,
+    /// Human-readable description of what was expected.
+    pub expected: Option<&'a str>,
+    /// Byte window captured near the error offset, when available.
+    pub bytes_near: Option<&'a BytesNear>,
+    /// Expected total record length per the leader; `TruncatedRecord` only.
+    pub expected_length: Option<usize>,
+    /// Actual bytes available before truncation; `TruncatedRecord` only.
+    pub actual_length: Option<usize>,
+    /// Configured recovered-error cap; `FatalReaderError` only.
+    pub cap: Option<usize>,
+    /// Recovered errors counted when the cap was hit; `FatalReaderError` only.
+    pub errors_seen: Option<usize>,
+}
+
+/// Mutable counterpart to [`ErrorMetadata`]: borrows the writable positional
+/// slots of a [`MarcError`] so enrichment helpers (`with_position`,
+/// `with_bytes_near`) need no per-variant `match` of their own.
+///
+/// `record_index` exists on every variant, so it is unconditional; the other
+/// slots are `None` for variants that do not carry the field.
+struct ErrorFieldsMut<'a> {
+    record_index: &'a mut Option<usize>,
+    byte_offset: Option<&'a mut Option<usize>>,
+    record_byte_offset: Option<&'a mut Option<usize>>,
+    source_name: Option<&'a mut Option<String>>,
+    bytes_near: Option<&'a mut Option<BytesNear>>,
+}
+
 /// Error type for all MARC library operations.
 ///
 /// Each variant carries structured positional metadata: the record index in
@@ -721,6 +787,489 @@ impl MarcError {
         out
     }
 
+    /// Borrowed snapshot of every piece of structured metadata this error
+    /// carries, plus its stable identifiers ([`ErrorMetadata::code`],
+    /// [`ErrorMetadata::slug`], [`ErrorMetadata::kind`]).
+    ///
+    /// This is the single per-variant `match` behind all of the per-field
+    /// accessors; fields the variant does not carry are `None`.
+    #[must_use]
+    #[allow(clippy::too_many_lines)] // one arm per variant, each bound explicitly
+    pub fn metadata(&self) -> ErrorMetadata<'_> {
+        match self {
+            MarcError::InvalidLeader {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                // The leader message renders through `body_text` only; it is
+                // deliberately absent from `metadata().message` so the
+                // `detailed()` and `to_json_value` shapes stay unchanged.
+                message: _,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E002",
+                slug: "leader_invalid",
+                kind: "InvalidLeader",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                record_byte_offset: *record_byte_offset,
+                source_name: source_name.as_deref(),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::RecordLengthInvalid {
+                record_index,
+                byte_offset,
+                source_name,
+                found,
+                expected,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E001",
+                slug: "record_length_invalid",
+                kind: "RecordLengthInvalid",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                source_name: source_name.as_deref(),
+                found: found.as_deref(),
+                expected: expected.as_deref(),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::BaseAddressInvalid {
+                record_index,
+                byte_offset,
+                source_name,
+                record_control_number,
+                found,
+                expected,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E003",
+                slug: "base_address_invalid",
+                kind: "BaseAddressInvalid",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                source_name: source_name.as_deref(),
+                record_control_number: record_control_number.as_deref(),
+                found: found.as_deref(),
+                expected: expected.as_deref(),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::BaseAddressNotFound {
+                record_index,
+                byte_offset,
+                source_name,
+                record_control_number,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E004",
+                slug: "base_address_not_found",
+                kind: "BaseAddressNotFound",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                source_name: source_name.as_deref(),
+                record_control_number: record_control_number.as_deref(),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::DirectoryInvalid {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                record_control_number,
+                field_tag,
+                found,
+                expected,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E101",
+                slug: "directory_invalid",
+                kind: "DirectoryInvalid",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                record_byte_offset: *record_byte_offset,
+                source_name: source_name.as_deref(),
+                record_control_number: record_control_number.as_deref(),
+                field_tag: field_tag.as_deref(),
+                found: found.as_deref(),
+                expected: expected.as_deref(),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::TruncatedRecord {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                record_control_number,
+                expected_length,
+                actual_length,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E005",
+                slug: "truncated_record",
+                kind: "TruncatedRecord",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                record_byte_offset: *record_byte_offset,
+                source_name: source_name.as_deref(),
+                record_control_number: record_control_number.as_deref(),
+                expected_length: *expected_length,
+                actual_length: *actual_length,
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::EndOfRecordNotFound {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                record_control_number,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E006",
+                slug: "end_of_record_not_found",
+                kind: "EndOfRecordNotFound",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                record_byte_offset: *record_byte_offset,
+                source_name: source_name.as_deref(),
+                record_control_number: record_control_number.as_deref(),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::InvalidIndicator {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                record_control_number,
+                field_tag,
+                indicator_position,
+                found,
+                expected,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E201",
+                slug: "invalid_indicator",
+                kind: "InvalidIndicator",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                record_byte_offset: *record_byte_offset,
+                source_name: source_name.as_deref(),
+                record_control_number: record_control_number.as_deref(),
+                field_tag: field_tag.as_deref(),
+                indicator_position: *indicator_position,
+                found: found.as_deref(),
+                expected: expected.as_deref(),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::BadSubfieldCode {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                record_control_number,
+                field_tag,
+                subfield_code,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E202",
+                slug: "bad_subfield_code",
+                kind: "BadSubfieldCode",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                record_byte_offset: *record_byte_offset,
+                source_name: source_name.as_deref(),
+                record_control_number: record_control_number.as_deref(),
+                field_tag: field_tag.as_deref(),
+                subfield_code: Some(*subfield_code),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::InvalidField {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                record_control_number,
+                field_tag,
+                message,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E106",
+                slug: "invalid_field",
+                kind: "InvalidField",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                record_byte_offset: *record_byte_offset,
+                source_name: source_name.as_deref(),
+                record_control_number: record_control_number.as_deref(),
+                field_tag: field_tag.as_deref(),
+                message: Some(message),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::EncodingError {
+                record_index,
+                byte_offset,
+                source_name,
+                record_control_number,
+                field_tag,
+                message,
+                bytes_near,
+            } => ErrorMetadata {
+                code: "E301",
+                slug: "utf8_invalid",
+                kind: "EncodingError",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                source_name: source_name.as_deref(),
+                record_control_number: record_control_number.as_deref(),
+                field_tag: field_tag.as_deref(),
+                message: Some(message),
+                bytes_near: bytes_near.as_ref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::FieldNotFound {
+                record_index,
+                record_control_number,
+                field_tag,
+            } => ErrorMetadata {
+                code: "E105",
+                slug: "field_not_found",
+                kind: "FieldNotFound",
+                record_index: *record_index,
+                record_control_number: record_control_number.as_deref(),
+                field_tag: Some(field_tag.as_str()),
+                ..ErrorMetadata::default()
+            },
+            MarcError::IoError {
+                cause: _,
+                record_index,
+                byte_offset,
+                source_name,
+            } => ErrorMetadata {
+                code: "E007",
+                slug: "io_error",
+                kind: "IoError",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                source_name: source_name.as_deref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::XmlError {
+                cause: _,
+                record_index,
+                byte_offset,
+                source_name,
+            } => ErrorMetadata {
+                code: "E401",
+                slug: "marcxml_invalid",
+                kind: "XmlError",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                source_name: source_name.as_deref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::JsonError {
+                cause: _,
+                record_index,
+                byte_offset,
+                source_name,
+            } => ErrorMetadata {
+                code: "E402",
+                slug: "marcjson_invalid",
+                kind: "JsonError",
+                record_index: *record_index,
+                byte_offset: *byte_offset,
+                source_name: source_name.as_deref(),
+                ..ErrorMetadata::default()
+            },
+            MarcError::WriterError {
+                record_index,
+                record_control_number,
+                message,
+            } => ErrorMetadata {
+                code: "E404",
+                slug: "record_too_large_for_iso2709",
+                kind: "WriterError",
+                record_index: *record_index,
+                record_control_number: record_control_number.as_deref(),
+                message: Some(message),
+                ..ErrorMetadata::default()
+            },
+            MarcError::FatalReaderError {
+                cap,
+                errors_seen,
+                record_index,
+                source_name,
+            } => ErrorMetadata {
+                code: "E099",
+                slug: "fatal_reader_error",
+                kind: "FatalReaderError",
+                record_index: *record_index,
+                source_name: source_name.as_deref(),
+                cap: Some(*cap),
+                errors_seen: Some(*errors_seen),
+                ..ErrorMetadata::default()
+            },
+        }
+    }
+
+    /// Mutable view of the writable positional slots; the single per-variant
+    /// `match` behind [`MarcError::with_position`] and
+    /// [`MarcError::with_bytes_near`].
+    #[allow(clippy::too_many_lines)] // one arm group per variant field-shape
+    fn fields_mut(&mut self) -> ErrorFieldsMut<'_> {
+        match self {
+            MarcError::InvalidLeader {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            }
+            | MarcError::DirectoryInvalid {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            }
+            | MarcError::TruncatedRecord {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            }
+            | MarcError::EndOfRecordNotFound {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            }
+            | MarcError::InvalidIndicator {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            }
+            | MarcError::BadSubfieldCode {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            }
+            | MarcError::InvalidField {
+                record_index,
+                byte_offset,
+                record_byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            } => ErrorFieldsMut {
+                record_index,
+                byte_offset: Some(byte_offset),
+                record_byte_offset: Some(record_byte_offset),
+                source_name: Some(source_name),
+                bytes_near: Some(bytes_near),
+            },
+            MarcError::RecordLengthInvalid {
+                record_index,
+                byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            }
+            | MarcError::BaseAddressInvalid {
+                record_index,
+                byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            }
+            | MarcError::BaseAddressNotFound {
+                record_index,
+                byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            }
+            | MarcError::EncodingError {
+                record_index,
+                byte_offset,
+                source_name,
+                bytes_near,
+                ..
+            } => ErrorFieldsMut {
+                record_index,
+                byte_offset: Some(byte_offset),
+                record_byte_offset: None,
+                source_name: Some(source_name),
+                bytes_near: Some(bytes_near),
+            },
+            MarcError::IoError {
+                record_index,
+                byte_offset,
+                source_name,
+                ..
+            }
+            | MarcError::XmlError {
+                record_index,
+                byte_offset,
+                source_name,
+                ..
+            }
+            | MarcError::JsonError {
+                record_index,
+                byte_offset,
+                source_name,
+                ..
+            } => ErrorFieldsMut {
+                record_index,
+                byte_offset: Some(byte_offset),
+                record_byte_offset: None,
+                source_name: Some(source_name),
+                bytes_near: None,
+            },
+            MarcError::FieldNotFound { record_index, .. }
+            | MarcError::WriterError { record_index, .. } => ErrorFieldsMut {
+                record_index,
+                byte_offset: None,
+                record_byte_offset: None,
+                source_name: None,
+                bytes_near: None,
+            },
+            MarcError::FatalReaderError {
+                record_index,
+                source_name,
+                ..
+            } => ErrorFieldsMut {
+                record_index,
+                byte_offset: None,
+                record_byte_offset: None,
+                source_name: Some(source_name),
+                bytes_near: None,
+            },
+        }
+    }
+
     /// Stable error code for this variant (`E001`–`E4xx`). Forms the
     /// canonical programmatic identifier — callers can match on this rather
     /// than on the variant name to keep handlers stable across enum
@@ -732,25 +1281,7 @@ impl MarcError {
     /// full stability policy.
     #[must_use]
     pub fn code(&self) -> &'static str {
-        match self {
-            MarcError::RecordLengthInvalid { .. } => "E001",
-            MarcError::InvalidLeader { .. } => "E002",
-            MarcError::BaseAddressInvalid { .. } => "E003",
-            MarcError::BaseAddressNotFound { .. } => "E004",
-            MarcError::TruncatedRecord { .. } => "E005",
-            MarcError::EndOfRecordNotFound { .. } => "E006",
-            MarcError::IoError { .. } => "E007",
-            MarcError::DirectoryInvalid { .. } => "E101",
-            MarcError::FieldNotFound { .. } => "E105",
-            MarcError::InvalidField { .. } => "E106",
-            MarcError::InvalidIndicator { .. } => "E201",
-            MarcError::BadSubfieldCode { .. } => "E202",
-            MarcError::EncodingError { .. } => "E301",
-            MarcError::XmlError { .. } => "E401",
-            MarcError::JsonError { .. } => "E402",
-            MarcError::WriterError { .. } => "E404",
-            MarcError::FatalReaderError { .. } => "E099",
-        }
+        self.metadata().code
     }
 
     /// Human-friendly slug for this variant (e.g., `"invalid_indicator"`).
@@ -758,25 +1289,7 @@ impl MarcError {
     /// to change for an existing variant.
     #[must_use]
     pub fn slug(&self) -> &'static str {
-        match self {
-            MarcError::RecordLengthInvalid { .. } => "record_length_invalid",
-            MarcError::InvalidLeader { .. } => "leader_invalid",
-            MarcError::BaseAddressInvalid { .. } => "base_address_invalid",
-            MarcError::BaseAddressNotFound { .. } => "base_address_not_found",
-            MarcError::TruncatedRecord { .. } => "truncated_record",
-            MarcError::EndOfRecordNotFound { .. } => "end_of_record_not_found",
-            MarcError::IoError { .. } => "io_error",
-            MarcError::DirectoryInvalid { .. } => "directory_invalid",
-            MarcError::FieldNotFound { .. } => "field_not_found",
-            MarcError::InvalidField { .. } => "invalid_field",
-            MarcError::InvalidIndicator { .. } => "invalid_indicator",
-            MarcError::BadSubfieldCode { .. } => "bad_subfield_code",
-            MarcError::EncodingError { .. } => "utf8_invalid",
-            MarcError::XmlError { .. } => "marcxml_invalid",
-            MarcError::JsonError { .. } => "marcjson_invalid",
-            MarcError::WriterError { .. } => "record_too_large_for_iso2709",
-            MarcError::FatalReaderError { .. } => "fatal_reader_error",
-        }
+        self.metadata().slug
     }
 
     /// Serialize this error as a JSON-ready `serde_json::Value` suitable
@@ -793,66 +1306,63 @@ impl MarcError {
     #[must_use]
     pub fn to_json_value(&self) -> serde_json::Value {
         use serde_json::{Map, Value, json};
+        let md = self.metadata();
         let mut m: Map<String, Value> = Map::new();
         m.insert("schema_version".into(), json!(SCHEMA_VERSION));
-        m.insert("class".into(), json!(self.kind_name()));
-        m.insert("code".into(), json!(self.code()));
-        m.insert("slug".into(), json!(self.slug()));
+        m.insert("class".into(), json!(md.kind));
+        m.insert("code".into(), json!(md.code));
+        m.insert("slug".into(), json!(md.slug));
         m.insert("severity".into(), json!("error"));
         m.insert("help_url".into(), json!(self.help_url()));
 
         // Positional fields, mirroring the Python _POSITIONAL_FIELDS list.
         // Fields the variant doesn't carry surface as null.
-        m.insert("record_index".into(), opt_json(self.record_index()));
+        m.insert("record_index".into(), opt_json(md.record_index));
         m.insert(
             "record_control_number".into(),
-            self.record_control_number()
-                .map_or(Value::Null, Value::from),
+            md.record_control_number.map_or(Value::Null, Value::from),
         );
         m.insert(
             "field_tag".into(),
-            self.field_tag().map_or(Value::Null, Value::from),
+            md.field_tag.map_or(Value::Null, Value::from),
         );
-        m.insert(
-            "indicator_position".into(),
-            opt_json(self.indicator_position_field()),
-        );
-        m.insert("subfield_code".into(), opt_json(self.subfield_code_field()));
+        m.insert("indicator_position".into(), opt_json(md.indicator_position));
+        m.insert("subfield_code".into(), opt_json(md.subfield_code));
         m.insert("found".into(), Value::Null);
-        if let Some(bytes) = self.found_field() {
+        if let Some(bytes) = md.found {
             m.insert("found_hex".into(), json!(hex_encode(bytes)));
         }
         m.insert(
             "expected".into(),
-            self.expected_field().map_or(Value::Null, Value::from),
+            md.expected.map_or(Value::Null, Value::from),
         );
-        m.insert("byte_offset".into(), opt_json(self.byte_offset()));
-        m.insert(
-            "record_byte_offset".into(),
-            opt_json(self.record_byte_offset()),
-        );
+        m.insert("byte_offset".into(), opt_json(md.byte_offset));
+        m.insert("record_byte_offset".into(), opt_json(md.record_byte_offset));
         m.insert(
             "source".into(),
-            self.source_name().map_or(Value::Null, Value::from),
+            md.source_name.map_or(Value::Null, Value::from),
         );
         // bytes_near is a byte-window surfaced via the `_hex` suffix
         // convention: `bytes_near` always None in the dict, `bytes_near_hex`
         // present only when bytes were captured. `bytes_near_offset` is the
         // absolute stream offset of the window's first byte.
         m.insert("bytes_near".into(), Value::Null);
-        if let Some(window) = self.bytes_near() {
+        if let Some(window) = md.bytes_near {
             m.insert("bytes_near_hex".into(), json!(hex_encode(&window.bytes)));
             m.insert("bytes_near_offset".into(), json!(window.start_offset));
         } else {
             m.insert("bytes_near_offset".into(), Value::Null);
         }
 
-        // Variant-specific extra fields (mirrors Python's
-        // _diagnostic_extra_fields). Surface the message / length pair
+        // Variant-specific extra fields (mirrors the Python classes'
+        // _extra_fields declarations). Surface the message / length pair
         // when applicable so downstream consumers don't lose them.
-        if let Some(msg) = self.message_text() {
+        if let Some(msg) = md.message {
             m.insert("message".into(), json!(msg));
         }
+        // Variant-matched (rather than metadata-driven) so the keys are
+        // emitted as nulls — not omitted — when a truncated record carries
+        // no length information, matching the Python to_dict() shape.
         if let MarcError::TruncatedRecord {
             expected_length,
             actual_length,
@@ -862,12 +1372,11 @@ impl MarcError {
             m.insert("expected_length".into(), opt_json(*expected_length));
             m.insert("actual_length".into(), opt_json(*actual_length));
         }
-        if let MarcError::FatalReaderError {
-            cap, errors_seen, ..
-        } = self
-        {
-            m.insert("cap".into(), json!(*cap));
-            m.insert("errors_seen".into(), json!(*errors_seen));
+        if let Some(cap) = md.cap {
+            m.insert("cap".into(), json!(cap));
+        }
+        if let Some(errors_seen) = md.errors_seen {
+            m.insert("errors_seen".into(), json!(errors_seen));
         }
 
         // Cause chain: stringified single value, never nested. Walks
@@ -891,45 +1400,6 @@ impl MarcError {
         serde_json::to_string(&self.to_json_value())
     }
 
-    /// Helper accessors for variants that carry the shared fields. These
-    /// abstract over per-variant field-set differences so `to_json_value`
-    /// can be written once.
-    fn indicator_position_field(&self) -> Option<u8> {
-        match self {
-            MarcError::InvalidIndicator {
-                indicator_position, ..
-            } => *indicator_position,
-            _ => None,
-        }
-    }
-
-    fn subfield_code_field(&self) -> Option<u8> {
-        match self {
-            MarcError::BadSubfieldCode { subfield_code, .. } => Some(*subfield_code),
-            _ => None,
-        }
-    }
-
-    fn found_field(&self) -> Option<&[u8]> {
-        match self {
-            MarcError::RecordLengthInvalid { found, .. }
-            | MarcError::BaseAddressInvalid { found, .. }
-            | MarcError::DirectoryInvalid { found, .. }
-            | MarcError::InvalidIndicator { found, .. } => found.as_deref(),
-            _ => None,
-        }
-    }
-
-    fn expected_field(&self) -> Option<&str> {
-        match self {
-            MarcError::RecordLengthInvalid { expected, .. }
-            | MarcError::BaseAddressInvalid { expected, .. }
-            | MarcError::DirectoryInvalid { expected, .. }
-            | MarcError::InvalidIndicator { expected, .. } => expected.as_deref(),
-            _ => None,
-        }
-    }
-
     /// Byte window captured near the error offset, when available.
     ///
     /// Returned for the parse-path variants that carry it; returns `None`
@@ -937,20 +1407,7 @@ impl MarcError {
     /// when the parser did not have access to a buffer at error time.
     #[must_use]
     pub fn bytes_near(&self) -> Option<&BytesNear> {
-        match self {
-            MarcError::InvalidLeader { bytes_near, .. }
-            | MarcError::RecordLengthInvalid { bytes_near, .. }
-            | MarcError::BaseAddressInvalid { bytes_near, .. }
-            | MarcError::BaseAddressNotFound { bytes_near, .. }
-            | MarcError::DirectoryInvalid { bytes_near, .. }
-            | MarcError::TruncatedRecord { bytes_near, .. }
-            | MarcError::EndOfRecordNotFound { bytes_near, .. }
-            | MarcError::InvalidIndicator { bytes_near, .. }
-            | MarcError::BadSubfieldCode { bytes_near, .. }
-            | MarcError::InvalidField { bytes_near, .. }
-            | MarcError::EncodingError { bytes_near, .. } => bytes_near.as_ref(),
-            _ => None,
-        }
+        self.metadata().bytes_near
     }
 
     /// Attach a byte-window to this error after the fact, enriching it for
@@ -979,68 +1436,16 @@ impl MarcError {
         let Some(window) = BytesNear::capture(buffer, buffer_start_offset, anchor) else {
             return self;
         };
-        match &mut self {
-            MarcError::InvalidLeader {
-                bytes_near,
-                byte_offset,
-                ..
+        let fields = self.fields_mut();
+        if let Some(bytes_near) = fields.bytes_near {
+            // Every variant that carries `bytes_near` also carries
+            // `byte_offset`, so the anchor backfill below always has a slot.
+            if let Some(byte_offset) = fields.byte_offset
+                && byte_offset.is_none()
+            {
+                *byte_offset = Some(buffer_start_offset);
             }
-            | MarcError::RecordLengthInvalid {
-                bytes_near,
-                byte_offset,
-                ..
-            }
-            | MarcError::BaseAddressInvalid {
-                bytes_near,
-                byte_offset,
-                ..
-            }
-            | MarcError::BaseAddressNotFound {
-                bytes_near,
-                byte_offset,
-                ..
-            }
-            | MarcError::DirectoryInvalid {
-                bytes_near,
-                byte_offset,
-                ..
-            }
-            | MarcError::TruncatedRecord {
-                bytes_near,
-                byte_offset,
-                ..
-            }
-            | MarcError::EndOfRecordNotFound {
-                bytes_near,
-                byte_offset,
-                ..
-            }
-            | MarcError::InvalidIndicator {
-                bytes_near,
-                byte_offset,
-                ..
-            }
-            | MarcError::BadSubfieldCode {
-                bytes_near,
-                byte_offset,
-                ..
-            }
-            | MarcError::InvalidField {
-                bytes_near,
-                byte_offset,
-                ..
-            }
-            | MarcError::EncodingError {
-                bytes_near,
-                byte_offset,
-                ..
-            } => {
-                if byte_offset.is_none() {
-                    *byte_offset = Some(buffer_start_offset);
-                }
-                *bytes_near = Some(window);
-            },
-            _ => {},
+            *bytes_near = Some(window);
         }
         self
     }
@@ -1063,121 +1468,18 @@ impl MarcError {
         } else {
             Some(ctx.record_index)
         };
-        *self.record_index_mut() = ridx;
-        if let Some(slot) = self.byte_offset_mut() {
+        let fields = self.fields_mut();
+        *fields.record_index = ridx;
+        if let Some(slot) = fields.byte_offset {
             *slot = Some(ctx.stream_byte_offset);
         }
-        if let Some(slot) = self.record_byte_offset_mut() {
+        if let Some(slot) = fields.record_byte_offset {
             *slot = Some(ctx.record_byte_offset());
         }
-        if let Some(slot) = self.source_name_mut() {
+        if let Some(slot) = fields.source_name {
             slot.clone_from(&ctx.source_name);
         }
         self
-    }
-
-    /// Mutable reference to the `record_index` field. Every variant
-    /// carries this field, so the return type is unconditional.
-    fn record_index_mut(&mut self) -> &mut Option<usize> {
-        match self {
-            MarcError::InvalidLeader { record_index, .. }
-            | MarcError::RecordLengthInvalid { record_index, .. }
-            | MarcError::BaseAddressInvalid { record_index, .. }
-            | MarcError::BaseAddressNotFound { record_index, .. }
-            | MarcError::DirectoryInvalid { record_index, .. }
-            | MarcError::TruncatedRecord { record_index, .. }
-            | MarcError::EndOfRecordNotFound { record_index, .. }
-            | MarcError::InvalidIndicator { record_index, .. }
-            | MarcError::BadSubfieldCode { record_index, .. }
-            | MarcError::InvalidField { record_index, .. }
-            | MarcError::EncodingError { record_index, .. }
-            | MarcError::FieldNotFound { record_index, .. }
-            | MarcError::IoError { record_index, .. }
-            | MarcError::XmlError { record_index, .. }
-            | MarcError::JsonError { record_index, .. }
-            | MarcError::WriterError { record_index, .. }
-            | MarcError::FatalReaderError { record_index, .. } => record_index,
-        }
-    }
-
-    /// Mutable reference to the `byte_offset` field, or `None` for
-    /// variants that don't carry one (`FieldNotFound`, `WriterError`,
-    /// `FatalReaderError`).
-    fn byte_offset_mut(&mut self) -> Option<&mut Option<usize>> {
-        match self {
-            MarcError::InvalidLeader { byte_offset, .. }
-            | MarcError::RecordLengthInvalid { byte_offset, .. }
-            | MarcError::BaseAddressInvalid { byte_offset, .. }
-            | MarcError::BaseAddressNotFound { byte_offset, .. }
-            | MarcError::DirectoryInvalid { byte_offset, .. }
-            | MarcError::TruncatedRecord { byte_offset, .. }
-            | MarcError::EndOfRecordNotFound { byte_offset, .. }
-            | MarcError::InvalidIndicator { byte_offset, .. }
-            | MarcError::BadSubfieldCode { byte_offset, .. }
-            | MarcError::InvalidField { byte_offset, .. }
-            | MarcError::EncodingError { byte_offset, .. }
-            | MarcError::IoError { byte_offset, .. }
-            | MarcError::XmlError { byte_offset, .. }
-            | MarcError::JsonError { byte_offset, .. } => Some(byte_offset),
-            MarcError::FieldNotFound { .. }
-            | MarcError::WriterError { .. }
-            | MarcError::FatalReaderError { .. } => None,
-        }
-    }
-
-    /// Mutable reference to the `record_byte_offset` field, or `None`
-    /// for variants whose failure precedes per-record offset semantics
-    /// (the leader-shape variants) or have no record context
-    /// (accessor / writer / format / I/O variants).
-    fn record_byte_offset_mut(&mut self) -> Option<&mut Option<usize>> {
-        match self {
-            MarcError::InvalidLeader {
-                record_byte_offset, ..
-            }
-            | MarcError::DirectoryInvalid {
-                record_byte_offset, ..
-            }
-            | MarcError::TruncatedRecord {
-                record_byte_offset, ..
-            }
-            | MarcError::EndOfRecordNotFound {
-                record_byte_offset, ..
-            }
-            | MarcError::InvalidIndicator {
-                record_byte_offset, ..
-            }
-            | MarcError::BadSubfieldCode {
-                record_byte_offset, ..
-            }
-            | MarcError::InvalidField {
-                record_byte_offset, ..
-            } => Some(record_byte_offset),
-            _ => None,
-        }
-    }
-
-    /// Mutable reference to the `source_name` field, or `None` for
-    /// variants that don't carry one.
-    fn source_name_mut(&mut self) -> Option<&mut Option<String>> {
-        match self {
-            MarcError::InvalidLeader { source_name, .. }
-            | MarcError::RecordLengthInvalid { source_name, .. }
-            | MarcError::BaseAddressInvalid { source_name, .. }
-            | MarcError::BaseAddressNotFound { source_name, .. }
-            | MarcError::DirectoryInvalid { source_name, .. }
-            | MarcError::TruncatedRecord { source_name, .. }
-            | MarcError::EndOfRecordNotFound { source_name, .. }
-            | MarcError::InvalidIndicator { source_name, .. }
-            | MarcError::BadSubfieldCode { source_name, .. }
-            | MarcError::InvalidField { source_name, .. }
-            | MarcError::EncodingError { source_name, .. }
-            | MarcError::IoError { source_name, .. }
-            | MarcError::XmlError { source_name, .. }
-            | MarcError::JsonError { source_name, .. } => Some(source_name),
-            MarcError::FieldNotFound { .. }
-            | MarcError::WriterError { .. }
-            | MarcError::FatalReaderError { .. } => None,
-        }
     }
 
     /// Canonical docs URL for this error code, pointing at the `#Exxx`
@@ -1193,25 +1495,7 @@ impl MarcError {
     /// Short `PascalCase` name for the variant, used in `detailed()` headers
     /// and as the leading token of the underlying-cause-less default `Display`.
     fn kind_name(&self) -> &'static str {
-        match self {
-            MarcError::InvalidLeader { .. } => "InvalidLeader",
-            MarcError::RecordLengthInvalid { .. } => "RecordLengthInvalid",
-            MarcError::BaseAddressInvalid { .. } => "BaseAddressInvalid",
-            MarcError::BaseAddressNotFound { .. } => "BaseAddressNotFound",
-            MarcError::DirectoryInvalid { .. } => "DirectoryInvalid",
-            MarcError::TruncatedRecord { .. } => "TruncatedRecord",
-            MarcError::EndOfRecordNotFound { .. } => "EndOfRecordNotFound",
-            MarcError::InvalidIndicator { .. } => "InvalidIndicator",
-            MarcError::BadSubfieldCode { .. } => "BadSubfieldCode",
-            MarcError::InvalidField { .. } => "InvalidField",
-            MarcError::EncodingError { .. } => "EncodingError",
-            MarcError::FieldNotFound { .. } => "FieldNotFound",
-            MarcError::IoError { .. } => "IoError",
-            MarcError::XmlError { .. } => "XmlError",
-            MarcError::JsonError { .. } => "JsonError",
-            MarcError::WriterError { .. } => "WriterError",
-            MarcError::FatalReaderError { .. } => "FatalReaderError",
-        }
+        self.metadata().kind
     }
 
     /// Build a "record N, field T" style context summary if those fields are
@@ -1228,69 +1512,51 @@ impl MarcError {
     }
 
     /// Produce the (label, value) detail lines for `detailed()` output, in
-    /// display order. Skips lines whose value is unavailable.
+    /// display order. Skips lines whose value is unavailable. At most one of
+    /// the variant-specific rows (indicator / subfield / length / cap) can
+    /// apply, since each is carried by exactly one variant.
     fn detail_lines(&self) -> Vec<(&'static str, String)> {
+        let md = self.metadata();
         let mut lines: Vec<(&'static str, String)> = Vec::new();
-        if let Some(s) = self.source_name() {
+        if let Some(s) = md.source_name {
             lines.push(("source:", s.to_string()));
         }
-        if let Some(cn) = self.record_control_number() {
+        if let Some(cn) = md.record_control_number {
             lines.push(("001:", cn.to_string()));
         }
-        match self {
-            MarcError::InvalidIndicator {
-                indicator_position,
-                found,
-                expected,
-                ..
-            } => {
-                if let (Some(pos), Some(exp)) = (indicator_position, expected) {
-                    let found_repr = found
-                        .as_deref()
-                        .map_or_else(|| "?".to_string(), format_found_bytes_python_repr);
-                    // Label carries the indicator number + colon; value is
-                    // just the found/expected so column alignment in
-                    // detailed() matches the Python side byte-for-byte.
-                    let label = if *pos == 0 {
-                        "indicator 0:"
-                    } else {
-                        "indicator 1:"
-                    };
-                    lines.push((label, format!("found {found_repr}, expected {exp}")));
-                }
-            },
-            MarcError::BadSubfieldCode { subfield_code, .. } => {
-                lines.push((
-                    "subfield:",
-                    format!(
-                        "invalid code byte 0x{subfield_code:02X} ({:?})",
-                        *subfield_code as char
-                    ),
-                ));
-            },
-            MarcError::TruncatedRecord {
-                expected_length,
-                actual_length,
-                ..
-            } => {
-                if let (Some(exp), Some(act)) = (expected_length, actual_length) {
-                    lines.push(("length:", format!("expected {exp} bytes, found {act}")));
-                }
-            },
-            MarcError::FatalReaderError {
-                cap, errors_seen, ..
-            } => {
-                lines.push(("cap:", format!("{errors_seen} errors seen, cap {cap}")));
-            },
-            _ => {},
+        if let (Some(pos), Some(exp)) = (md.indicator_position, md.expected) {
+            let found_repr = md
+                .found
+                .map_or_else(|| "?".to_string(), format_found_bytes_python_repr);
+            // Label carries the indicator number + colon; value is just the
+            // found/expected so column alignment in detailed() matches the
+            // Python side byte-for-byte.
+            let label = if pos == 0 {
+                "indicator 0:"
+            } else {
+                "indicator 1:"
+            };
+            lines.push((label, format!("found {found_repr}, expected {exp}")));
         }
-        if let Some(off) = self.byte_offset() {
+        if let Some(code) = md.subfield_code {
+            lines.push((
+                "subfield:",
+                format!("invalid code byte 0x{code:02X} ({:?})", code as char),
+            ));
+        }
+        if let (Some(exp), Some(act)) = (md.expected_length, md.actual_length) {
+            lines.push(("length:", format!("expected {exp} bytes, found {act}")));
+        }
+        if let (Some(cap), Some(errors_seen)) = (md.cap, md.errors_seen) {
+            lines.push(("cap:", format!("{errors_seen} errors seen, cap {cap}")));
+        }
+        if let Some(off) = md.byte_offset {
             lines.push(("byte offset:", format!("0x{off:X} ({off}) in stream")));
         }
-        if let Some(off) = self.record_byte_offset() {
+        if let Some(off) = md.record_byte_offset {
             lines.push(("record-relative:", format!("byte {off}")));
         }
-        if let Some(msg) = self.message_text() {
+        if let Some(msg) = md.message {
             lines.push(("message:", msg.to_string()));
         }
         lines
@@ -1300,32 +1566,29 @@ impl MarcError {
     /// (when available) and the problem description; appends the byte offset
     /// in hex/decimal as a visually subordinate trailer.
     fn render_oneline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let md = self.metadata();
         let mut header_parts: Vec<String> = Vec::new();
-        if let Some(idx) = self.record_index() {
+        if let Some(idx) = md.record_index {
             header_parts.push(format!("record {idx}"));
         }
-        if let Some(cn) = self.record_control_number() {
+        if let Some(cn) = md.record_control_number {
             header_parts.push(format!("001 '{cn}'"));
         }
-        if let Some(tag) = self.field_tag() {
+        if let Some(tag) = md.field_tag {
             header_parts.push(format!("field {tag}"));
         }
-        if let MarcError::InvalidIndicator {
-            indicator_position: Some(pos),
-            ..
-        } = self
-        {
+        if let Some(pos) = md.indicator_position {
             header_parts.push(format!("ind{pos}"));
         }
         if header_parts.is_empty() {
             // No positional context available — lead with the variant name so
             // the message at least identifies what kind of error it is.
-            write!(f, "{}: ", self.kind_name())?;
+            write!(f, "{}: ", md.kind)?;
         } else {
             write!(f, "[{}] ", header_parts.join(" · "))?;
         }
         write!(f, "{}", self.body_text())?;
-        if let Some(off) = self.byte_offset() {
+        if let Some(off) = md.byte_offset {
             write!(f, "  (byte 0x{off:X} / {off})")?;
         }
         Ok(())
@@ -1403,164 +1666,15 @@ impl MarcError {
     }
 
     fn record_index(&self) -> Option<usize> {
-        match self {
-            MarcError::InvalidLeader { record_index, .. }
-            | MarcError::RecordLengthInvalid { record_index, .. }
-            | MarcError::BaseAddressInvalid { record_index, .. }
-            | MarcError::BaseAddressNotFound { record_index, .. }
-            | MarcError::DirectoryInvalid { record_index, .. }
-            | MarcError::TruncatedRecord { record_index, .. }
-            | MarcError::EndOfRecordNotFound { record_index, .. }
-            | MarcError::InvalidIndicator { record_index, .. }
-            | MarcError::BadSubfieldCode { record_index, .. }
-            | MarcError::InvalidField { record_index, .. }
-            | MarcError::EncodingError { record_index, .. }
-            | MarcError::FieldNotFound { record_index, .. }
-            | MarcError::IoError { record_index, .. }
-            | MarcError::XmlError { record_index, .. }
-            | MarcError::JsonError { record_index, .. }
-            | MarcError::WriterError { record_index, .. }
-            | MarcError::FatalReaderError { record_index, .. } => *record_index,
-        }
-    }
-
-    fn record_control_number(&self) -> Option<&str> {
-        match self {
-            MarcError::BaseAddressInvalid {
-                record_control_number,
-                ..
-            }
-            | MarcError::BaseAddressNotFound {
-                record_control_number,
-                ..
-            }
-            | MarcError::DirectoryInvalid {
-                record_control_number,
-                ..
-            }
-            | MarcError::TruncatedRecord {
-                record_control_number,
-                ..
-            }
-            | MarcError::EndOfRecordNotFound {
-                record_control_number,
-                ..
-            }
-            | MarcError::InvalidIndicator {
-                record_control_number,
-                ..
-            }
-            | MarcError::BadSubfieldCode {
-                record_control_number,
-                ..
-            }
-            | MarcError::InvalidField {
-                record_control_number,
-                ..
-            }
-            | MarcError::EncodingError {
-                record_control_number,
-                ..
-            }
-            | MarcError::FieldNotFound {
-                record_control_number,
-                ..
-            }
-            | MarcError::WriterError {
-                record_control_number,
-                ..
-            } => record_control_number.as_deref(),
-            _ => None,
-        }
+        self.metadata().record_index
     }
 
     fn field_tag(&self) -> Option<&str> {
-        match self {
-            MarcError::DirectoryInvalid { field_tag, .. }
-            | MarcError::InvalidIndicator { field_tag, .. }
-            | MarcError::BadSubfieldCode { field_tag, .. }
-            | MarcError::InvalidField { field_tag, .. }
-            | MarcError::EncodingError { field_tag, .. } => field_tag.as_deref(),
-            MarcError::FieldNotFound { field_tag, .. } => Some(field_tag.as_str()),
-            _ => None,
-        }
+        self.metadata().field_tag
     }
 
     fn byte_offset(&self) -> Option<usize> {
-        match self {
-            MarcError::InvalidLeader { byte_offset, .. }
-            | MarcError::RecordLengthInvalid { byte_offset, .. }
-            | MarcError::BaseAddressInvalid { byte_offset, .. }
-            | MarcError::BaseAddressNotFound { byte_offset, .. }
-            | MarcError::DirectoryInvalid { byte_offset, .. }
-            | MarcError::TruncatedRecord { byte_offset, .. }
-            | MarcError::EndOfRecordNotFound { byte_offset, .. }
-            | MarcError::InvalidIndicator { byte_offset, .. }
-            | MarcError::BadSubfieldCode { byte_offset, .. }
-            | MarcError::InvalidField { byte_offset, .. }
-            | MarcError::EncodingError { byte_offset, .. }
-            | MarcError::IoError { byte_offset, .. }
-            | MarcError::XmlError { byte_offset, .. }
-            | MarcError::JsonError { byte_offset, .. } => *byte_offset,
-            _ => None,
-        }
-    }
-
-    fn record_byte_offset(&self) -> Option<usize> {
-        match self {
-            MarcError::InvalidLeader {
-                record_byte_offset, ..
-            }
-            | MarcError::DirectoryInvalid {
-                record_byte_offset, ..
-            }
-            | MarcError::TruncatedRecord {
-                record_byte_offset, ..
-            }
-            | MarcError::EndOfRecordNotFound {
-                record_byte_offset, ..
-            }
-            | MarcError::InvalidIndicator {
-                record_byte_offset, ..
-            }
-            | MarcError::BadSubfieldCode {
-                record_byte_offset, ..
-            }
-            | MarcError::InvalidField {
-                record_byte_offset, ..
-            } => *record_byte_offset,
-            _ => None,
-        }
-    }
-
-    fn source_name(&self) -> Option<&str> {
-        match self {
-            MarcError::InvalidLeader { source_name, .. }
-            | MarcError::RecordLengthInvalid { source_name, .. }
-            | MarcError::BaseAddressInvalid { source_name, .. }
-            | MarcError::BaseAddressNotFound { source_name, .. }
-            | MarcError::DirectoryInvalid { source_name, .. }
-            | MarcError::TruncatedRecord { source_name, .. }
-            | MarcError::EndOfRecordNotFound { source_name, .. }
-            | MarcError::InvalidIndicator { source_name, .. }
-            | MarcError::BadSubfieldCode { source_name, .. }
-            | MarcError::InvalidField { source_name, .. }
-            | MarcError::EncodingError { source_name, .. }
-            | MarcError::IoError { source_name, .. }
-            | MarcError::XmlError { source_name, .. }
-            | MarcError::JsonError { source_name, .. }
-            | MarcError::FatalReaderError { source_name, .. } => source_name.as_deref(),
-            _ => None,
-        }
-    }
-
-    fn message_text(&self) -> Option<&str> {
-        match self {
-            MarcError::InvalidField { message, .. }
-            | MarcError::EncodingError { message, .. }
-            | MarcError::WriterError { message, .. } => Some(message.as_str()),
-            _ => None,
-        }
+        self.metadata().byte_offset
     }
 }
 
@@ -1998,6 +2112,32 @@ mod tests {
             err.help_url(),
             format!("{DOCS_BASE_URL}/reference/error-codes/#E105"),
         );
+    }
+
+    #[test]
+    fn metadata_snapshot_exposes_all_carried_fields() {
+        let err = invalid_indicator_full();
+        let md = err.metadata();
+        assert_eq!(md.code, "E201");
+        assert_eq!(md.slug, "invalid_indicator");
+        assert_eq!(md.kind, "InvalidIndicator");
+        assert_eq!(md.record_index, Some(847));
+        assert_eq!(md.byte_offset, Some(7217));
+        assert_eq!(md.record_byte_offset, Some(42));
+        assert_eq!(md.source_name, Some("harvest.mrc"));
+        assert_eq!(md.record_control_number, Some("ocm01234567"));
+        assert_eq!(md.field_tag, Some("245"));
+        assert_eq!(md.indicator_position, Some(1));
+        assert_eq!(md.found, Some(b":".as_slice()));
+        assert_eq!(md.expected, Some("digit or space"));
+        // Fields this variant does not carry stay None.
+        assert!(md.bytes_near.is_none());
+        assert!(md.message.is_none());
+        assert!(md.subfield_code.is_none());
+        assert!(md.expected_length.is_none());
+        assert!(md.actual_length.is_none());
+        assert!(md.cap.is_none());
+        assert!(md.errors_seen.is_none());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub use authority_record::{
 pub use authority_writer::AuthorityMarcWriter;
 pub use bibliographic_helpers::{IsbnValidator, PublicationInfo};
 pub use encoding_validation::{EncodingAnalysis, EncodingValidator};
-pub use error::{BytesNear, MarcError, Result};
+pub use error::{BytesNear, ErrorMetadata, MarcError, Result};
 pub use field_linkage::LinkageInfo;
 pub use field_query::{FieldQuery, SubfieldPatternQuery, SubfieldValueQuery, TagRangeQuery};
 pub use field_query_helpers::FieldQueryHelpers;


### PR DESCRIPTION
## Summary

Adding a `MarcError` variant previously meant touching ~17 match sites: `code()`, `slug()`, `kind_name()`, eight per-field accessors, the `with_position()`/`with_bytes_near()` mutators, the `to_json_value()` extras, the PyO3 `describe()` mapping, and the Python mirror class. This PR collapses the field extraction into one table per side.

- `MarcError::metadata()` returns a new public `ErrorMetadata<'_>` snapshot (code, slug, kind, and every `Option` field the variant carries) built by a single `match` over all variants; a crate-private `fields_mut()` counterpart serves the enrichment helpers. All per-field accessors, `Display`/`detailed()` rendering, and JSON serialization are now one-line reads of that table.
- `src-python/src/error.rs::describe()` populates the positional kwargs uniformly from `metadata()`; only the Python class name and the per-class extra kwargs keep a (much smaller) per-variant match.
- `mrrc/exceptions.py` mirrors the consolidation: a single per-class `_extra_fields` tuple now drives `__init__` kwargs, pickle round-trips, and `to_dict()` output, replacing eight per-class `__init__` overrides and the duplicated `_pickle_extra_fields`/`_diagnostic_extra_fields` declarations.
- `scripts/verify_error_docs.py` parses variant-to-code pairs from the `metadata()` arms.

Public accessor signatures, rendered output, and serialized shapes are unchanged — all insta and syrupy snapshots pass untouched, and the error-code reconciliation gate still reads 17/17 codes.

## Test plan

- `.cargo/check.sh` green end to end (569 Rust tests, 926 Python tests, snapshot suites, mypy/pyright/stubtest, error-code reconciliation).
- New unit test `metadata_snapshot_exposes_all_carried_fields` pins the snapshot contents for a fully populated variant.

Bead: bd-hgv6

🤖 Generated with [Claude Code](https://claude.com/claude-code)