### PR TITLE
Fuzz the new parser targets on schedule; run integration tests under ASAN

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -42,7 +42,7 @@ jobs:
       # cancelling the other.
       fail-fast: false
       matrix:
-        target: [parse_record, roundtrip_binary, error_classification, recovery_mode_consistency, parse_json, parse_marcjson, parse_marcxml, parse_mods, decode_marc8]
+        target: [parse_record, roundtrip_binary, error_classification, recovery_mode_consistency, parse_json, parse_marcjson, parse_marcxml, parse_mods, decode_marc8, parse_authority, parse_holdings, parse_bibframe, parse_lenient]
 
     steps:
       - uses: actions/checkout@v6.0.3

--- a/.github/workflows/memory-safety.yml
+++ b/.github/workflows/memory-safety.yml
@@ -36,7 +36,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-asan-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run ASAN on library tests
+      - name: Run ASAN on library and integration tests
         env:
           # Override rust-toolchain.toml pin so -Zbuild-std uses the nightly
           # toolchain installed above rather than the stable channel.
@@ -46,7 +46,7 @@ jobs:
           export LSAN_OPTIONS="suppressions=${{ github.workspace }}/.cargo/asan_suppressions.txt"
           # Use -Zbuild-std to rebuild std with ASAN and properly handle proc-macros
           # Proc-macros run on host at compile time, so they need special handling
-          cargo test --lib --package mrrc -q -Zbuild-std --target x86_64-unknown-linux-gnu
+          cargo test --lib --tests --package mrrc -q -Zbuild-std --target x86_64-unknown-linux-gnu
 
       - name: Report results
         if: always()


### PR DESCRIPTION
Follow-ups from the test-integrity work that could not land with it: the scheduled fuzz workflow's hardcoded matrix gains the four targets added by #315 (parse_authority, parse_holdings, parse_bibframe, parse_lenient), and the nightly ASAN job runs `--tests` in addition to `--lib` so the rebuilt integration-level memory-safety workload from #310 actually executes under the sanitizer.

Bead: bd-eoyi

🤖 Generated with [Claude Code](https://claude.com/claude-code)