### PR TITLE
Bound lenient-recovery allocation by input size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   MSRV unlocked clippy-driven cleanups: the MARC-8 tables now use `std::sync::LazyLock`
   (dropping the `lazy_static` dependency) and I/O error construction uses
   `std::io::Error::other`.
+- Truncated records no longer allocate or zero-pad a buffer of the leader's claimed
+  length: the reader grows the record buffer as bytes arrive (8 KiB steps) and lenient
+  salvage parses the short body directly, so allocation is bounded by actual input size
+  instead of a claimed maximum-length record on a small stub.
 
 ### Removed
 

--- a/src/iso2709.rs
+++ b/src/iso2709.rs
@@ -390,14 +390,25 @@ pub fn read_leader_bytes<R: Read>(reader: &mut R) -> Result<Option<[u8; LEADER_L
     }
 }
 
+/// Growth step for [`read_record_data`]'s record buffer. The buffer is
+/// extended one chunk at a time as bytes actually arrive, so its capacity
+/// never exceeds the smaller of the leader's claimed length and the bytes
+/// the stream delivered plus one chunk — a stub record claiming the ISO
+/// 2709 maximum cannot force a maximum-length allocation.
+pub const READ_CHUNK_LEN: usize = 8192;
+
 /// Read the remaining `record_length - 24` bytes of a MARC record after the
 /// leader has already been consumed.
 ///
-/// Returns `(data, was_truncated)` where `was_truncated` is `true` when the
-/// read hit EOF before filling the buffer. In [`RecoveryMode::Strict`] a short
-/// read returns a [`MarcError::TruncatedRecord`] enriched with the current
-/// positional context (record index, byte offset, source filename, 001 if
-/// already extracted) plus the expected/actual byte counts.
+/// Returns `(data, bytes_read)` where `data` holds exactly the bytes the
+/// stream delivered (`data.len() == bytes_read`); a count short of
+/// `record_length - 24` means the read hit EOF mid-record. The buffer grows
+/// in [`READ_CHUNK_LEN`] steps, so its capacity is bounded by
+/// `min(record_length - 24, bytes_read + READ_CHUNK_LEN)` rather than by
+/// the leader's claim. In [`RecoveryMode::Strict`] a short read returns a
+/// [`MarcError::TruncatedRecord`] enriched with the current positional
+/// context (record index, byte offset, source filename, 001 if already
+/// extracted) plus the expected/actual byte counts.
 ///
 /// # Errors
 ///
@@ -411,9 +422,17 @@ pub fn read_record_data<R: Read>(
     ctx: &ParseContext,
 ) -> Result<(Vec<u8>, usize)> {
     let expected_len = record_length.saturating_sub(LEADER_LEN);
-    let mut data = vec![0u8; expected_len];
+    let mut data: Vec<u8> = Vec::new();
     let mut bytes_read = 0;
     while bytes_read < expected_len {
+        if bytes_read == data.len() {
+            let target = expected_len.min(bytes_read + READ_CHUNK_LEN);
+            // reserve_exact (not resize's amortized reserve) keeps the
+            // capacity bound exact; at most ceil(99975 / 8192) = 13
+            // reallocations for a maximum-length record.
+            data.reserve_exact(target - data.len());
+            data.resize(target, 0);
+        }
         match reader.read(&mut data[bytes_read..]) {
             Ok(0) => break,
             Ok(n) => bytes_read += n,
@@ -421,6 +440,7 @@ pub fn read_record_data<R: Read>(
             Err(e) => return Err(ctx.err_io(e)),
         }
     }
+    data.truncate(bytes_read);
     if bytes_read < expected_len && recovery_mode == RecoveryMode::Strict {
         return Err(ctx.err_truncated_record(Some(expected_len), Some(bytes_read)));
     }
@@ -967,10 +987,31 @@ mod tests {
             read_record_data(&mut reader, 100, RecoveryMode::Lenient, &ctx).unwrap();
         assert_eq!(
             data.len(),
-            76,
-            "buffer is sized to expected_len, zero-padded"
+            50,
+            "buffer holds exactly the bytes the stream delivered"
         );
         assert_eq!(bytes_read, 50, "actual bytes read short of expected_len");
+    }
+
+    #[test]
+    fn read_record_data_allocation_bounded_by_available_bytes() {
+        // A 25-byte stub whose leader claims the ISO 2709 maximum must not
+        // allocate the claimed 99975-byte body; the buffer is bounded by
+        // the bytes actually available plus one growth chunk.
+        let available = 1usize;
+        let mut reader = Cursor::new(vec![b'x'; available]);
+        let ctx = ParseContext::new();
+        let (data, bytes_read) =
+            read_record_data(&mut reader, 99_999, RecoveryMode::Lenient, &ctx).unwrap();
+        assert_eq!(bytes_read, available);
+        assert_eq!(data.len(), available);
+        assert!(
+            data.capacity() <= available + READ_CHUNK_LEN,
+            "capacity {} exceeds available {} + chunk {}",
+            data.capacity(),
+            available,
+            READ_CHUNK_LEN
+        );
     }
 
     #[test]

--- a/src/iso2709_skeleton.rs
+++ b/src/iso2709_skeleton.rs
@@ -227,10 +227,12 @@ where
     ctx.advance(LEADER_LEN);
 
     // Read the full record data. In non-Strict modes a short read returns
-    // a zero-padded buffer of `expected_len` plus the actual bytes_read;
-    // strict mode has already errored out via `?`. The truncated-record
-    // dispatch in `parse_record_body` is the lenient/permissive recovery
-    // point. Wrapping in Arc moves the Vec (no byte copy).
+    // just the bytes the stream delivered (`record_data.len()` equals
+    // `bytes_read`, bounded by input size — not by the leader's claimed
+    // length); strict mode has already errored out via `?`. The
+    // truncated-record dispatch in `parse_record_body` is the
+    // lenient/permissive recovery point. Wrapping in Arc moves the Vec
+    // (no byte copy).
     let (record_data, bytes_read) = read_record_data(reader, record_length, recovery_mode, ctx)?;
     let record_data = std::sync::Arc::new(record_data);
     let body_range = 0..record_data.len();
@@ -358,20 +360,22 @@ pub fn parse_iso2709_record_from_bytes<B: Iso2709Builder>(
 
     let body_len = record_bytes.len() - LEADER_LEN;
     if body_len < expected_data_len {
-        // Mirror read_record_data's short-read behavior: strict aborts with
-        // E005; lenient/permissive parse a zero-padded body so downstream
-        // recovery sees the same input shape as the reader path. The pad
-        // copy happens only on this truncated-record path.
+        // Mirror read_record_data's short-read behavior: strict aborts
+        // with E005; lenient/permissive hand the short body to the
+        // clamped directory walk. The buffer holds only the bytes the
+        // caller actually supplied — never one sized (or zero-padded) to
+        // the leader's claimed length — so allocation stays bounded by
+        // input size. The body-only copy keeps error hex-dump windows
+        // identical to the reader path's body-only buffer, and happens
+        // only on this truncated-record path.
         if recovery_mode == RecoveryMode::Strict {
             return Err(ctx.err_truncated_record(Some(expected_data_len), Some(body_len)));
         }
-        let mut padded = record_bytes[LEADER_LEN..].to_vec();
-        padded.resize(expected_data_len, 0);
-        let padded = std::sync::Arc::new(padded);
-        let range = 0..expected_data_len;
+        let body = std::sync::Arc::new(record_bytes[LEADER_LEN..].to_vec());
+        let range = 0..body_len;
         return parse_record_body::<B>(
             leader,
-            &padded,
+            &body,
             range,
             ctx.stream_byte_offset,
             body_len,

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -1068,6 +1068,41 @@ proptest! {
         while let Ok(Some(_)) = reader.read_record() {}
     }
 
+    /// On the lenient path, the record-body buffer's allocation is bounded
+    /// by the bytes the stream actually delivers (plus one growth chunk),
+    /// never by the leader's claimed record length: a tiny stub claiming
+    /// the ISO 2709 maximum must not force a maximum-length allocation.
+    #[test]
+    fn lenient_read_allocation_bounded_by_input_size(
+        record_length in (LEADER_LEN + 1)..=99_999usize,
+        available_seed in any::<u32>(),
+    ) {
+        let expected_body = record_length - LEADER_LEN;
+        // Strictly fewer bytes than claimed, so the lenient short-read
+        // path runs (0 up to expected_body - 1 bytes available).
+        let available = (available_seed as usize) % expected_body;
+        let body = vec![b'x'; available];
+
+        let mut cursor = Cursor::new(&body[..]);
+        let ctx = mrrc::iso2709::ParseContext::new();
+        let (data, bytes_read) = mrrc::iso2709::read_record_data(
+            &mut cursor,
+            record_length,
+            RecoveryMode::Lenient,
+            &ctx,
+        ).expect("lenient short read must not error");
+
+        prop_assert_eq!(bytes_read, available);
+        prop_assert_eq!(data.len(), available, "no padding to the claimed length");
+        prop_assert!(
+            data.capacity() <= available + mrrc::iso2709::READ_CHUNK_LEN,
+            "capacity {} exceeds available {} + chunk {}",
+            data.capacity(),
+            available,
+            mrrc::iso2709::READ_CHUNK_LEN
+        );
+    }
+
     /// Permissive mode must swallow record-internal malformations: when
     /// the leader parses cleanly (so the reader can advance to the next
     /// record boundary) but the field area is malformed, no error


### PR DESCRIPTION
## Summary

`read_record_data` pre-allocated a zeroed buffer of the leader's claimed record length before reading any bytes, so a 25-byte stub record claiming the ISO 2709 maximum (99999) forced a ~100 KB allocation per record — roughly 4000x amplification on attacker-shaped input (DoS-class only; bounded per record by the ISO ceiling). The buffer now grows in 8 KiB steps (`READ_CHUNK_LEN`, exported from `mrrc::iso2709`) as bytes actually arrive, using `reserve_exact` so capacity is bounded by `min(claimed - 24, bytes_read + READ_CHUNK_LEN)`. Typical records (< 8 KiB) still get a single exact-size allocation; a maximum-length record costs at most 13 reallocations.

A short read now returns only the bytes the stream delivered — no zero-padding to the claimed length. `parse_iso2709_record_from_bytes`'s truncated branch likewise stops padding its body copy to the claim: the copy holds just the supplied bytes, which keeps error hex-dump windows identical to the reader path (the from-bytes/reader parity test caught that the zero-copy full-buffer alternative widened the `bytes_near` window on the truncation diagnostic, so the bounded body-only copy is kept). The salvage walk already clamps the directory and data slices to the real buffer length, so dropping the padding changes no salvage results.

## Tests

- New property test `lenient_read_allocation_bounded_by_input_size` in `tests/properties.rs` pins the capacity bound (`capacity <= available + READ_CHUNK_LEN`) across arbitrary claimed/available pairs on the lenient path.
- New unit test pins the maximum-claim stub case (1 byte available, 99999 claimed) directly.
- Existing truncation, salvage, parity, and recovery-cap tests pass unchanged except the lenient short-read unit test, updated for the no-padding return shape.
- `.cargo/check.sh` passes.

Source finding: TEST-6 in the v0.8.2 code-review findings.

Stacked on #323 (salvage consolidation); base is that PR's branch.

Bead: bd-pk26.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)