### PR TITLE
Make MARCReader.current_chunk lazy; share the parse buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no reader I/O and no per-record copies. The Python `MARCReader` read path now uses it,
   collapsing the former chain of per-record buffer copies between the source and the
   parser to a single pymarc-compatibility stash (`current_chunk`).
+- `parse_record_from_shared_bytes`: parse from a buffer the caller already holds behind an
+  `Arc`, without taking ownership. The Python `MARCReader` uses it so the `current_chunk`
+  stash shares one allocation with the parser instead of cloning, and `current_chunk` is now
+  read lazily — iterating without inspecting it copies no record bytes into Python.
 - Criterion benches for the serialization formats that had no CI perf signal — CSV, MODS,
   Dublin Core, BIBFRAME (Turtle), and MARC-in-JSON (both directions for MODS and
   MARC-in-JSON) — plus a single-thread parser-pool bench that tracks the

--- a/mrrc/__init__.py
+++ b/mrrc/__init__.py
@@ -1762,16 +1762,17 @@ class MARCReader:
             validation_level=validation_level,
             max_errors=max_errors,
         )
-        # pymarc-compat accessors populated by __next__. `current_chunk`
-        # tracks the bytes of the most recent record chunk read from the
-        # source (regardless of whether the parse succeeded);
-        # `current_exception` is the typed mrrc exception caught from
-        # the most recent parse attempt, or None on a clean read. Both
-        # mirror pymarc.MARCReader semantics so existing pymarc-shape
-        # error-diagnosis code (``if reader.current_exception: ...``)
-        # works against mrrc unchanged.
+        # pymarc-compat accessors fed by __next__. `current_exception` is
+        # the typed mrrc exception caught from the most recent parse attempt,
+        # or None on a clean read. `current_chunk` (see the property below)
+        # is read lazily from the inner reader so iterating without inspecting
+        # it copies no record bytes into Python. `_chunk_live` records whether
+        # __next__ has read a chunk yet; iter_with_errors deliberately leaves
+        # it False so it never feeds these accessors. Both mirror
+        # pymarc.MARCReader semantics so existing pymarc-shape error-diagnosis
+        # code (``if reader.current_exception: ...``) works unchanged.
         self.current_exception: Exception | None = None
-        self.current_chunk: bytes | None = None
+        self._chunk_live = False
 
     def __iter__(self):
         """Iterate over records."""
@@ -1793,13 +1794,28 @@ class MARCReader:
             raise
         except Exception as e:
             if self._permissive:
-                self.current_chunk = self._inner.last_chunk
+                self._chunk_live = True
                 self.current_exception = e
                 return None
             raise
-        self.current_chunk = self._inner.last_chunk
+        self._chunk_live = True
         self.current_exception = None
         return _wrap_record(record)
+
+    @property
+    def current_chunk(self) -> bytes | None:
+        """Bytes of the most recent record read by ``__next__``.
+
+        Fetched lazily from the inner reader on access, so iterating without
+        inspecting ``current_chunk`` copies no record bytes into Python.
+        Mirrors pymarc: holds the most recent read's chunk whether the parse
+        succeeded or was swallowed under ``permissive=True``, and retains its
+        value after the iterator is exhausted. Stays ``None`` until the first
+        ``__next__``; ``iter_with_errors`` does not feed it.
+        """
+        if not self._chunk_live:
+            return None
+        return self._inner.last_chunk
 
     @property
     def backend_type(self) -> str:

--- a/src-python/src/readers.rs
+++ b/src-python/src/readers.rs
@@ -90,8 +90,11 @@ pub struct PyMARCReader {
     /// of whether the parse subsequently succeeds or fails). The
     /// `mrrc.MARCReader` Python wrapper exposes this as the
     /// pymarc-compatible `current_chunk` accessor used to diagnose
-    /// records swallowed by `permissive=True`.
-    last_chunk: Option<Vec<u8>>,
+    /// records swallowed by `permissive=True`. Held behind a shared
+    /// `Arc` so stashing the most recent chunk costs a refcount bump,
+    /// not a byte copy: the same allocation is borrowed by the parser
+    /// (via `parse_record_from_shared_bytes`) and retained here.
+    last_chunk: Option<std::sync::Arc<Vec<u8>>>,
 }
 
 #[pymethods]
@@ -177,7 +180,7 @@ impl PyMARCReader {
     /// `current_chunk` semantics.
     #[getter]
     fn last_chunk(&self) -> Option<&[u8]> {
-        self.last_chunk.as_deref()
+        self.last_chunk.as_ref().map(|chunk| chunk.as_slice())
     }
 
     /// Read the next record from the file (legacy interface)
@@ -208,9 +211,10 @@ impl PyMARCReader {
                     // Stash the chunk for pymarc-compat `current_chunk`. Set
                     // unconditionally — success and failure callers both want
                     // it (success readers can compare; failure readers can
-                    // diagnose). The one remaining per-record copy on this
-                    // path; the owned bytes move into the parse below.
-                    self.last_chunk = Some(bytes.clone());
+                    // diagnose). Sharing the `Arc` with the parser below means
+                    // this stash is a refcount bump, not a byte copy.
+                    let shared = std::sync::Arc::new(bytes);
+                    self.last_chunk = Some(std::sync::Arc::clone(&shared));
 
                     // Step 2: Parse bytes (GIL released). Return the raw
                     // MarcError across the GIL boundary so the typed variant
@@ -221,7 +225,7 @@ impl PyMARCReader {
                     let val_level = self.validation_level;
                     let parse_result: Result<Option<mrrc::Record>, Box<mrrc::MarcError>> = py
                         .detach(|| {
-                            mrrc::parse_record_from_bytes(bytes, rec_mode, val_level)
+                            mrrc::parse_record_from_shared_bytes(&shared, rec_mode, val_level)
                                 .map_err(Box::new)
                         });
                     let record =
@@ -282,12 +286,14 @@ impl PyMARCReader {
     /// - Python files use same batching and GIL management
     fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<PyRecord> {
         // ===== STEP 1: Read record bytes (GIL held if needed) =====
-        // Must get Python handle while GIL is held by PyRefMut
-        // CRITICAL: Use assume_attached() to get an unbound Python handle that
-        // properly releases the GIL in Phase 2. A bound handle (slf.py()) does not.
-        // SAFETY: PyRefMut guarantees the GIL is held; this is the idiomatic way to get
-        // an unbound Python handle without re-acquiring (which would panic if already held).
-        // See GIL_RELEASE_IMPLEMENTATION_PLAN.md Part 2 Fix 2 (lines 149-235).
+        // Must get a Python handle while the GIL is held by PyRefMut.
+        // assume_attached() yields an unbound handle whose py.detach() in
+        // Phase 2 actually releases the GIL; a bound handle (slf.py()) would
+        // not.
+        // SAFETY: PyRefMut guarantees the GIL is held for the duration of
+        // this call, so the attachment assumption holds. This is the
+        // idiomatic way to obtain an unbound handle without re-acquiring,
+        // which would panic when the GIL is already held.
         let py = unsafe { Python::assume_attached() };
 
         // Get mutable reference to reader backend
@@ -319,11 +325,12 @@ impl PyMARCReader {
             },
         };
 
-        // Stash the chunk for pymarc-compat `current_chunk` — the one
-        // remaining per-record copy on this path (making it lazy is
-        // tracked separately). The owned Vec from read_next_record_bytes
-        // moves into the parse below without further copies.
-        slf.last_chunk = Some(record_bytes.clone());
+        // Stash the chunk for pymarc-compat `current_chunk`. The owned Vec
+        // from read_next_record_bytes is moved into a shared `Arc` that both
+        // the parser (below) and this stash borrow, so retaining the most
+        // recent chunk costs only a refcount bump — no per-record byte copy.
+        let shared = std::sync::Arc::new(record_bytes);
+        slf.last_chunk = Some(std::sync::Arc::clone(&shared));
 
         // ===== STEP 2: Parse bytes (GIL released) =====
         // Parse the record while GIL is released to allow other threads to execute.
@@ -337,7 +344,7 @@ impl PyMARCReader {
         let rec_mode = slf.recovery_mode;
         let val_level = slf.validation_level;
         let parse_result: Result<Option<mrrc::Record>, Box<mrrc::MarcError>> = py.detach(|| {
-            mrrc::parse_record_from_bytes(record_bytes, rec_mode, val_level).map_err(Box::new)
+            mrrc::parse_record_from_shared_bytes(&shared, rec_mode, val_level).map_err(Box::new)
         });
 
         // ===== STEP 3: Convert to PyRecord (GIL re-acquired) =====

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub use holdings_writer::HoldingsMarcWriter;
 pub use leader::Leader;
 pub use marc_record::MarcRecord;
 pub use producer_consumer_pipeline::{PipelineConfig, PipelineError, ProducerConsumerPipeline};
-pub use reader::{MarcReader, parse_record_from_bytes};
+pub use reader::{MarcReader, parse_record_from_bytes, parse_record_from_shared_bytes};
 pub use record::{Field, FieldBuilder, Record, RecordBuilder, Subfield};
 pub use record_builder_generic::GenericRecordBuilder;
 pub use record_helpers::RecordHelpers;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -344,11 +344,37 @@ pub fn parse_record_from_bytes(
     recovery_mode: RecoveryMode,
     validation_level: ValidationLevel,
 ) -> Result<Option<Record>> {
+    parse_record_from_shared_bytes(
+        &std::sync::Arc::new(record_bytes),
+        recovery_mode,
+        validation_level,
+    )
+}
+
+/// Parse one complete MARC record from a buffer the caller already holds
+/// behind a shared [`Arc`](std::sync::Arc), without taking ownership of the bytes.
+///
+/// Identical in behavior to [`parse_record_from_bytes`], but lets a caller
+/// that must retain the record bytes after parsing — for example to expose
+/// pymarc's `current_chunk` — share a single allocation between the parser
+/// and its own state instead of cloning. The parser borrows the buffer; the
+/// caller keeps its `Arc` handle alive for as long as it needs the bytes.
+///
+/// # Errors
+///
+/// Same as [`parse_record_from_bytes`]: malformed bytes yield an error (in
+/// `Strict` mode the first structural defect; in recovery modes only
+/// unrecoverable ones).
+pub fn parse_record_from_shared_bytes(
+    record_bytes: &std::sync::Arc<Vec<u8>>,
+    recovery_mode: RecoveryMode,
+    validation_level: ValidationLevel,
+) -> Result<Option<Record>> {
     let mut ctx = ParseContext::new();
     let mut cap = RecoveryCap::new();
     let mut errors = Vec::new();
     let result = crate::iso2709_skeleton::parse_iso2709_record_from_bytes::<BibBuilder>(
-        &std::sync::Arc::new(record_bytes),
+        record_bytes,
         &mut ctx,
         &mut cap,
         recovery_mode,

--- a/tests/parse_from_bytes_tests.rs
+++ b/tests/parse_from_bytes_tests.rs
@@ -6,8 +6,12 @@
 //! yields exactly what `MarcReader` yields for the same bytes — including
 //! error behavior on truncated input.
 
-use mrrc::{MarcReader, RecoveryMode, ValidationLevel, parse_record_from_bytes};
+use mrrc::{
+    MarcReader, RecoveryMode, ValidationLevel, parse_record_from_bytes,
+    parse_record_from_shared_bytes,
+};
 use std::io::Cursor;
+use std::sync::Arc;
 
 fn fixture_1k() -> Vec<u8> {
     let path = concat!(
@@ -57,6 +61,43 @@ fn slice_parse_matches_reader_parse_over_the_corpus() {
             format!("{from_slice:?}"),
             "record {count} diverged between reader and slice parse"
         );
+        count += 1;
+    }
+    assert_eq!(count, 1000);
+}
+
+#[test]
+fn shared_bytes_parse_matches_owned_bytes_parse_over_the_corpus() {
+    // `parse_record_from_shared_bytes` is the zero-copy entry point the
+    // Python bindings use so the `current_chunk` stash can share one
+    // allocation with the parser. It must yield exactly what the owned-bytes
+    // entry point yields for the same bytes.
+    let stream = fixture_1k();
+    let mut count = 0;
+    for record_bytes in split_records(&stream) {
+        let shared = Arc::new(record_bytes.clone());
+        let from_owned = parse_record_from_bytes(
+            record_bytes,
+            RecoveryMode::Strict,
+            ValidationLevel::Structural,
+        )
+        .expect("owned parse")
+        .expect("owned record");
+        let from_shared = parse_record_from_shared_bytes(
+            &shared,
+            RecoveryMode::Strict,
+            ValidationLevel::Structural,
+        )
+        .expect("shared parse")
+        .expect("shared record");
+        assert_eq!(
+            format!("{from_owned:?}"),
+            format!("{from_shared:?}"),
+            "record {count} diverged between owned and shared parse"
+        );
+        // The caller still holds the buffer after parsing — the whole point
+        // of the shared entry point.
+        assert!(!shared.is_empty());
         count += 1;
     }
     assert_eq!(count, 1000);

--- a/tests/python/test_pymarc_compat_accessors.py
+++ b/tests/python/test_pymarc_compat_accessors.py
@@ -184,6 +184,26 @@ def test_accessors_retain_last_values_after_stop_iteration() -> None:
     assert reader.current_exception is None
 
 
+def test_current_chunk_is_lazy_and_idempotent() -> None:
+    """``current_chunk`` is a lazy property: repeated access returns equal
+    bytes and does not advance the iterator, and it tracks each new read."""
+    bytes_ = (_REPO_ROOT / "tests" / "data" / "multi_records.mrc").read_bytes()
+    reader = mrrc.MARCReader(bytes_, permissive=True)
+
+    first_record = next(reader)
+    assert first_record is not None
+    chunk_a = reader.current_chunk
+    chunk_b = reader.current_chunk
+    assert chunk_a is not None
+    assert chunk_a == chunk_b  # stable across repeated access
+
+    # Reading current_chunk did not consume the next record.
+    second_record = next(reader)
+    assert second_record is not None
+    # After advancing, current_chunk reflects the new record's bytes.
+    assert reader.current_chunk != chunk_a
+
+
 def test_current_chunk_tracks_in_default_strict_mode() -> None:
     """``current_chunk`` is populated on every successful chunk read
     regardless of ``permissive``. Strict-mode iteration over a clean


### PR DESCRIPTION
PERF-4 from the v0.8.2 code review. The read path stashed a full per-record copy into `last_chunk`, and the Python wrapper materialized a fresh `bytes` object per record for `current_chunk` — two full-record copies on every iteration, even when nobody inspected `current_chunk`. This removes both.

## What changed

**Rust core.** New `parse_record_from_shared_bytes(&Arc<Vec<u8>>, …)` — a zero-copy entry point that borrows a buffer the caller already holds behind an `Arc` instead of taking ownership. `parse_record_from_bytes` now delegates to it, so behavior is identical (covered by a new equivalence test over the 1k corpus).

**Bindings.** `readers.rs` moves each record's bytes into a shared `Arc`, stashes a refcount-bumped clone as `last_chunk`, and parses through the shared handle. The per-record byte copy on the read path is gone — the stash is now a refcount bump.

**Python wrapper.** `current_chunk` is now a lazy property reading `_inner.last_chunk` on access, gated by a `_chunk_live` flag that only `__next__` sets. Iterating without inspecting `current_chunk` copies no bytes into Python. pymarc semantics preserved: most-recent read's chunk, success or failure, retained after exhaustion. `iter_with_errors` still never feeds the accessors (it sets no flag) — locked by the existing `test_iter_with_errors_does_not_clobber_accessors`.

Also replaces the stale `GIL_RELEASE_IMPLEMENTATION_PLAN.md` comment in `__next__` with the actual safety invariant (absorbed OPS-10h).

## Measurement (per epic protocol)

Apple M4, release build, `MARCReader(path)` iteration without reading `current_chunk`, 7 runs, median rec/s:

| Corpus | main | branch | Δ |
|--------|------|--------|---|
| 10k | 363k (325–370k) | 374k (333–380k) | +3%, within noise |
| 100k | 367k (339–377k) | 403k (397–407k) | +10%, non-overlapping ranges |

Neutral at 10k, a small but consistent improvement at 100k — matches the epic's 2026-06-12 note that copy-elimination is near-free on M4's memory bandwidth and shows up structurally (allocator pressure) rather than as a large wall-clock win. CodSpeed CI captures the instruction-count delta. The structural change (no per-record byte copy, no per-record PyBytes) is the durable result; the new equivalence test pins parser behavior.

## Test

`.cargo/check.sh` green. New tests: Rust equivalence test for the shared entry point; Python lazy/idempotent `current_chunk` test. Existing pymarc-compat accessor suite unchanged and green.

Bead: bd-0pg6.4