### PR TITLE
Read Python file objects in chunks instead of per record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reading from a Python file-like object (`MARCReader(open(path, "rb"))`, `BytesIO`, etc.)
+  now reads the source in 256 KiB chunks and slices records out in Rust, instead of two
+  `file.read()` calls plus a `getattr("read")` per record. The `read` method is bound once
+  and each chunk is borrowed via `PyBytes` rather than copied. Output is unchanged; file-path
+  and bytes inputs were already chunked and are unaffected.
 - `Cargo.lock` is now committed, so CI, wheel builds, and local checkouts resolve the
   same dependency versions; Dependabot manages version bumps as reviewable diffs.
 - Removed unused dependencies (`bytes`, `nom`, `encoding_rs`, `csv`, bindings-crate

--- a/src-python/src/backend.rs
+++ b/src-python/src/backend.rs
@@ -5,6 +5,7 @@
 //! - `CursorBackend`: In-memory reads from bytes via std::io::Cursor
 //! - `PythonFile`: Python file-like objects (calls .read() method)
 
+use crate::chunked_py_reader::ChunkedPyFileReader;
 use crate::parse_error::ParseError;
 use mrrc::RecoveryMode;
 use pyo3::prelude::*;
@@ -48,8 +49,9 @@ enum BackendKind {
 
     /// Python file-like object (fallback for custom types)
     /// Input: Any object with .read() method
-    /// Requires GIL for each read operation
-    PythonFile(Py<PyAny>),
+    /// Reads in large chunks and slices records out in Rust; the GIL is
+    /// held only while a chunk is being read, not per record.
+    PythonFile(ChunkedPyFileReader),
 }
 
 impl ReaderBackend {
@@ -75,14 +77,17 @@ impl ReaderBackend {
         _py: Python,
         recovery_mode: RecoveryMode,
     ) -> PyResult<Self> {
-        let kind = Self::kind_from_python(source)?;
+        let kind = Self::kind_from_python(source, recovery_mode)?;
         Ok(ReaderBackend {
             kind,
             recovery_mode,
         })
     }
 
-    fn kind_from_python(source: &Bound<'_, PyAny>) -> PyResult<BackendKind> {
+    fn kind_from_python(
+        source: &Bound<'_, PyAny>,
+        recovery_mode: RecoveryMode,
+    ) -> PyResult<BackendKind> {
         // 1. Try str path
         if let Ok(path_str) = source.extract::<String>() {
             return match File::open(&path_str) {
@@ -150,8 +155,11 @@ impl ReaderBackend {
         if let Ok(method) = read_method
             && method.is_callable()
         {
-            // Store as PythonFile backend
-            return Ok(BackendKind::PythonFile(source.clone().unbind()));
+            // Store as PythonFile backend, reading in large chunks.
+            return Ok(BackendKind::PythonFile(ChunkedPyFileReader::new(
+                source,
+                recovery_mode,
+            )?));
         }
 
         // 5. Unknown type - fail fast with descriptive error
@@ -193,10 +201,10 @@ impl ReaderBackend {
             BackendKind::CursorBackend(cursor) => {
                 Self::read_record_bytes_from_reader(cursor, recovery_mode)
             },
-            BackendKind::PythonFile(py_obj) => {
-                // Need GIL to call Python .read() method
-                let obj = py_obj.bind(py);
-                Self::read_record_bytes_from_python(obj, recovery_mode)
+            BackendKind::PythonFile(chunked) => {
+                // GIL is held only while a chunk is read; the chunked reader
+                // serves most records straight from its buffer.
+                chunked.read_next_record_bytes(py)
             },
         }
     }
@@ -281,84 +289,6 @@ impl ReaderBackend {
 
         // Assemble record bytes (full record in Strict; leader +
         // whatever body was read in Lenient/Permissive on short reads).
-        let mut complete_record = Vec::with_capacity(24 + record_data.len());
-        complete_record.extend_from_slice(&leader);
-        complete_record.extend_from_slice(&record_data);
-
-        Ok(Some(complete_record))
-    }
-
-    /// Internal helper: Read record bytes from Python file-like object
-    fn read_record_bytes_from_python(
-        py_obj: &Bound<'_, PyAny>,
-        recovery_mode: RecoveryMode,
-    ) -> Result<Option<Vec<u8>>, ParseError> {
-        // Read leader (24 bytes)
-        let read_method = py_obj
-            .getattr("read")
-            .map_err(|e| ParseError::io_error(format!("Object missing .read() method: {}", e)))?;
-
-        let leader_result = read_method.call1((24usize,)).map_err(|e| {
-            ParseError::io_error(format!("Failed to read leader from Python file: {}", e))
-        })?;
-
-        let leader: Vec<u8> = leader_result
-            .extract()
-            .map_err(|_| ParseError::invalid_record("Leader must be bytes".to_string()))?;
-
-        if leader.len() != 24 {
-            // EOF or partial read
-            if leader.is_empty() {
-                return Ok(None); // EOF
-            }
-            return Err(ParseError::invalid_record(format!(
-                "Incomplete leader: expected 24 bytes, got {}",
-                leader.len()
-            ))
-            .with_bytes_near(&leader, 0));
-        }
-
-        // Parse record length from leader
-        let record_length: usize = std::str::from_utf8(&leader[0..5])
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .ok_or_else(|| {
-                ParseError::record_length_invalid(&leader[0..5], "5 ASCII digits")
-                    .with_bytes_near(&leader, 0)
-            })?;
-
-        if record_length < 24 {
-            return Err(
-                ParseError::record_length_invalid(&leader[0..5], "at least 24")
-                    .with_bytes_near(&leader, 0),
-            );
-        }
-
-        // Read remainder of record
-        let record_data_bytes = read_method.call1((record_length - 24,)).map_err(|e| {
-            ParseError::io_error(format!(
-                "Failed to read record data from Python file: {}",
-                e
-            ))
-        })?;
-
-        let record_data: Vec<u8> = record_data_bytes
-            .extract()
-            .map_err(|_| ParseError::invalid_record("Record data must be bytes".to_string()))?;
-
-        if record_data.len() != record_length - 24 {
-            // Strict: fatal E005. Lenient/Permissive: hand the
-            // partial body through to the parser's recovery cap.
-            if recovery_mode == RecoveryMode::Strict {
-                return Err(
-                    ParseError::truncated_record(record_length - 24, record_data.len())
-                        .with_record_byte_offset(24),
-                );
-            }
-        }
-
-        // Assemble record bytes (full record in Strict; leader +
-        // whatever body was returned in Lenient/Permissive on short reads).
         let mut complete_record = Vec::with_capacity(24 + record_data.len());
         complete_record.extend_from_slice(&leader);
         complete_record.extend_from_slice(&record_data);

--- a/src-python/src/chunked_py_reader.rs
+++ b/src-python/src/chunked_py_reader.rs
@@ -1,0 +1,177 @@
+//! Chunked reader for Python file-like objects.
+//!
+//! The per-record Python read path used to issue two `file.read()` calls
+//! and a fresh `getattr("read")` for every record, then copy the result
+//! twice (`extract::<Vec<u8>>` into a `Vec`, then into the record buffer).
+//! At ~150 records per 256 KiB that is two GIL-held Python calls per record
+//! where one per chunk suffices.
+//!
+//! `ChunkedPyFileReader` reads large fixed-size chunks into an internal
+//! buffer, binds the `read` method once at construction, borrows each
+//! chunk through `PyBytes::as_bytes` instead of extracting an owned
+//! `Vec`, and slices complete ISO 2709 records out of the buffer in Rust.
+//! Record boundaries are found from the leader's 5-digit length field, so
+//! records that span a chunk boundary are reassembled transparently.
+//!
+//! Error behavior matches the previous `backend.rs` Python path exactly:
+//! an empty first read is EOF; a partial leader is `Incomplete leader`; a
+//! short body is a fatal `TruncatedRecord` (strict) or a pass-through of
+//! the partial record to the parser's `record.errors` dispatch
+//! (lenient/permissive).
+
+use crate::parse_error::ParseError;
+use mrrc::RecoveryMode;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+/// Bytes requested per `read()` call. One chunk holds roughly 150 average
+/// MARC records, so a stream is drained in one Python call per chunk rather
+/// than two per record.
+const CHUNK_SIZE: usize = 256 * 1024;
+
+/// Buffered reader over a Python file-like object that serves complete
+/// ISO 2709 records while reading from the source in large chunks.
+#[derive(Debug)]
+pub struct ChunkedPyFileReader {
+    /// The file object's `read` method, captured once so each refill is a
+    /// direct call rather than a per-record `getattr`.
+    read_method: Py<PyAny>,
+    /// Bytes read from the source but not yet served as records.
+    buffer: Vec<u8>,
+    /// Offset of the first unconsumed byte in `buffer`.
+    pos: usize,
+    /// Set once `read()` returns empty; no further Python calls are made.
+    eof: bool,
+    recovery_mode: RecoveryMode,
+}
+
+impl ChunkedPyFileReader {
+    /// Bind the object's `read` method once and wrap it for chunked reading.
+    pub fn new(file_obj: &Bound<'_, PyAny>, recovery_mode: RecoveryMode) -> PyResult<Self> {
+        let read_method = file_obj.getattr("read")?.unbind();
+        Ok(ChunkedPyFileReader {
+            read_method,
+            buffer: Vec::new(),
+            pos: 0,
+            eof: false,
+            recovery_mode,
+        })
+    }
+
+    /// Unconsumed bytes currently buffered.
+    fn available(&self) -> usize {
+        self.buffer.len() - self.pos
+    }
+
+    /// Read chunks until at least `needed` unconsumed bytes are buffered or
+    /// the source is exhausted. Compacts the consumed prefix first so the
+    /// buffer does not grow without bound; this runs at most once per chunk
+    /// (callers only fill when a record is not already fully buffered).
+    fn fill_to(&mut self, py: Python<'_>, needed: usize) -> Result<(), ParseError> {
+        if self.pos > 0 {
+            self.buffer.drain(..self.pos);
+            self.pos = 0;
+        }
+        while !self.eof && self.buffer.len() < needed {
+            let result = self
+                .read_method
+                .bind(py)
+                .call1((CHUNK_SIZE,))
+                .map_err(|e| ParseError::io_error(format!("Python read() failed: {}", e)))?;
+
+            // Fast path: a `bytes` return is borrowed and copied once into
+            // the buffer. `bytearray`/other buffer types fall back to an
+            // owned extract so custom file-likes keep working.
+            match result.cast::<PyBytes>() {
+                Ok(py_bytes) => {
+                    let slice = py_bytes.as_bytes();
+                    if slice.is_empty() {
+                        self.eof = true;
+                        break;
+                    }
+                    self.buffer.extend_from_slice(slice);
+                },
+                Err(_) => {
+                    let owned: Vec<u8> = result.extract().map_err(|_| {
+                        ParseError::invalid_record("read() must return bytes".to_string())
+                    })?;
+                    if owned.is_empty() {
+                        self.eof = true;
+                        break;
+                    }
+                    self.buffer.extend_from_slice(&owned);
+                },
+            }
+        }
+        Ok(())
+    }
+
+    /// Read the next complete MARC record from the buffered source.
+    ///
+    /// Returns `Ok(None)` at a clean end of stream, `Ok(Some(bytes))` for a
+    /// complete record (or, in lenient/permissive mode, a short final
+    /// record the parser will diagnose), and `Err` for a malformed leader
+    /// or a strict-mode truncation.
+    pub fn read_next_record_bytes(
+        &mut self,
+        py: Python<'_>,
+    ) -> Result<Option<Vec<u8>>, ParseError> {
+        // A complete record needs at least the 24-byte leader.
+        if self.available() < 24 {
+            self.fill_to(py, 24)?;
+        }
+        let avail = self.available();
+        if avail == 0 {
+            return Ok(None); // clean EOF on a record boundary
+        }
+        if avail < 24 {
+            // Some bytes, but not a full leader — same shape as the former
+            // backend.rs Python path's "Incomplete leader" error.
+            let near = &self.buffer[self.pos..];
+            return Err(ParseError::invalid_record(format!(
+                "Incomplete leader: expected 24 bytes, got {}",
+                avail
+            ))
+            .with_bytes_near(near, 0));
+        }
+
+        let record_length = {
+            let leader = &self.buffer[self.pos..self.pos + 24];
+            let record_length: usize = std::str::from_utf8(&leader[0..5])
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .ok_or_else(|| {
+                    ParseError::record_length_invalid(&leader[0..5], "5 ASCII digits")
+                        .with_bytes_near(leader, 0)
+                })?;
+            if record_length < 24 {
+                return Err(
+                    ParseError::record_length_invalid(&leader[0..5], "at least 24")
+                        .with_bytes_near(leader, 0),
+                );
+            }
+            record_length
+        };
+
+        // Ensure the whole record is buffered before slicing it out.
+        if self.available() < record_length {
+            self.fill_to(py, record_length)?;
+        }
+        let take = self.available().min(record_length);
+        let record = self.buffer[self.pos..self.pos + take].to_vec();
+        self.pos += take;
+
+        if take < record_length {
+            // Body fell short of the declared length. The leader (24 bytes)
+            // is present; the shortfall is in the body.
+            if self.recovery_mode == RecoveryMode::Strict {
+                return Err(ParseError::truncated_record(record_length - 24, take - 24)
+                    .with_record_byte_offset(24));
+            }
+            // Lenient/Permissive: hand the leader + partial body to the
+            // parser, which dispatches its own E005 onto `record.errors`.
+        }
+
+        Ok(Some(record))
+    }
+}

--- a/src-python/src/lib.rs
+++ b/src-python/src/lib.rs
@@ -8,6 +8,7 @@ mod batched_unified_reader;
 mod bibframe;
 mod boundary_scanner_wrapper;
 mod buffered_reader;
+mod chunked_py_reader;
 mod error;
 mod formats;
 mod holdings_readers;


### PR DESCRIPTION
PERF-5 from the v0.8.2 code review. Reading from a Python file-like object went through `backend.rs`'s `PythonFile` path, which issued **two** `file.read()` round-trips plus a fresh `getattr("read")` for every record, then copied the result twice (`extract::<Vec<u8>>` into a `Vec`, then into the record buffer). The batching layer amortized GIL acquire/release but not the per-record Python call count — "it changes when these calls happen, not how many."

## What changed

New `ChunkedPyFileReader` (`chunked_py_reader.rs`):
- **Binds `read` once** at construction instead of a `getattr` per record.
- **Reads 256 KiB chunks** into an internal buffer; one `read()` call serves ~150 records.
- **Borrows each chunk via `PyBytes::as_bytes`** (zero-copy) instead of `extract::<Vec<u8>>`, with a `bytearray`/other fallback for custom file-likes.
- **Slices complete records out in Rust** by leader length, reassembling records that span a chunk boundary. The buffer compacts its consumed prefix at most once per chunk.

`backend.rs`'s `BackendKind::PythonFile` now holds a `ChunkedPyFileReader` and delegates to it; the old per-record `read_record_bytes_from_python` helper is removed.

## Scope: the live path only

A real `open(path, "rb")` or `BytesIO` reaches `ReaderBackend::PythonFile` via `BatchedUnifiedReader → UnifiedReader`. The other two readers with the same per-record shape — `buffered_reader.rs` (`BatchedMarcReader`) and `unified_reader.rs`'s `Python` arm — are unreachable for valid inputs (`ReaderBackend` already captures every `.read()` object as `PythonFile`). They're left untouched here and are slated for removal under **bd-0pg6.6** (unify the batched readers).

## Behavior preserved

Error semantics match the former `backend.rs` path exactly: empty first read → EOF; partial leader → `Incomplete leader`; short body → fatal `TruncatedRecord` (strict, `record_byte_offset = 24`) or a partial pass-through to the parser (lenient/permissive). `test_backend_parity.py` (RustFile vs PythonFile, record-by-record) and the batch/queue/boundary suites all pass.

## Measurement (per epic protocol)

Apple M4, release build, `MARCReader(open(path, "rb"))` iteration, 7 runs, median rec/s:

| Corpus | main | branch | Δ |
|--------|------|--------|---|
| 10k | 380k (339–388k) | 402k (350–411k) | +5.6% |
| 100k | 380k (367–386k) | 408k (399–411k) | +7.5%, non-overlapping ranges |

A clear win, unlike PERF-4's copy-elimination — removing the per-record `getattr` and the extra `read()`/`extract` is real Python-boundary work, not just allocator pressure.

## Test

`.cargo/check.sh` green. 904 Python tests pass (file-object path covered by `test_backend_parity`, `test_batch_reading`, `test_queue_state_machine`, `test_authority_holdings_reading`, `test_record_boundary_scanner`).

Bead: bd-0pg6.5