### PR TITLE
Hoist hot-path regexes into LazyLock statics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- MARCXML deserialization and 880-linkage parsing no longer recompile their regexes on
+  every call (hoisted to `LazyLock` statics). Parsing MARCXML records one at a time — e.g.
+  `parse_xml_to_array` in a loop — is substantially faster; batch/whole-document parsing
+  already amortized the cost and is unchanged.
 - Reading from a Python file-like object (`MARCReader(open(path, "rb"))`, `BytesIO`, etc.)
   now reads the source in 256 KiB chunks and slices records out in Rust, instead of two
   `file.read()` calls plus a `getattr("read")` per record. The `read` method is bound once

--- a/benches/marc_benchmarks.rs
+++ b/benches/marc_benchmarks.rs
@@ -5,7 +5,7 @@
 //! MARC records using Criterion.rs for statistical analysis.
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use mrrc::{MarcReader, MarcWriter, RecordHelpers, json, marcxml};
+use mrrc::{LinkageInfo, MarcReader, MarcWriter, RecordHelpers, json, marcxml};
 use std::io::Cursor;
 
 /// Load test fixtures from the test data directory.
@@ -155,6 +155,45 @@ fn benchmark_serialization_to_xml_1k(c: &mut Criterion) {
     });
 }
 
+/// Benchmark MARCXML deserialization of a single record.
+///
+/// Exercises `strip_marcxml_ns` once per iteration — the per-call path PERF-7
+/// made compile-free by hoisting its namespace regexes to statics. A
+/// whole-document parse amortizes that cost over the whole collection and
+/// hides it; this single-record form is the regression sensor for it (the
+/// `serialize_1k_to_xml` bench only covers the write path).
+fn benchmark_deserialize_marcxml_record(c: &mut Criterion) {
+    let fixture = load_fixture("1k_records.mrc");
+    let mut reader = MarcReader::new(Cursor::new(fixture));
+    let record = reader
+        .read_record()
+        .expect("read fixture record")
+        .expect("fixture has at least one record");
+    let xml = black_box(marcxml::record_to_marcxml(&record).expect("serialize to MARCXML"));
+
+    c.bench_function("deserialize_marcxml_record", |b| {
+        b.iter(|| {
+            let _ = black_box(marcxml::marcxml_to_record(black_box(&xml)));
+        });
+    });
+}
+
+/// Benchmark MARC subfield-6 (880 linkage) parsing.
+///
+/// `LinkageInfo::parse` runs per field during 880-linkage scans; PERF-7
+/// hoisted its regex to a static. Regression sensor for that path.
+fn benchmark_parse_linkage(c: &mut Criterion) {
+    let values = black_box(["880-01", "100-02/(3/r", "245-01/(2/r", "650-03"]);
+
+    c.bench_function("parse_linkage_subfield6", |b| {
+        b.iter(|| {
+            for v in values {
+                black_box(LinkageInfo::parse(black_box(v)));
+            }
+        });
+    });
+}
+
 /// Benchmark read + write roundtrip of 1,000 MARC records.
 fn benchmark_roundtrip_1k(c: &mut Criterion) {
     let fixture = black_box(load_fixture("1k_records.mrc"));
@@ -215,6 +254,8 @@ criterion_group!(
     benchmark_read_with_field_access_10k,
     benchmark_serialization_to_json_1k,
     benchmark_serialization_to_xml_1k,
+    benchmark_deserialize_marcxml_record,
+    benchmark_parse_linkage,
     benchmark_roundtrip_1k,
     benchmark_roundtrip_10k,
 );

--- a/src/field_linkage.rs
+++ b/src/field_linkage.rs
@@ -24,6 +24,20 @@
 //! The occurrence numbers match to link the fields together.
 
 use regex::Regex;
+use std::sync::LazyLock;
+
+/// Subfield-6 linkage pattern: `TAG-OCC[/SCRIPT][/r]`.
+///
+/// - `TAG` = 3-digit field tag (e.g. 880, 100, 245)
+/// - `OCC` = 2-3 digit occurrence number
+/// - `SCRIPT` = optional MARC script code, parenthesized (`(2`, `(3`, `(B`,
+///   `(N`, `(S`, …) or dollar-sign (`$1` for CJK)
+/// - `/r` = optional right-to-left field orientation
+///
+/// Compiled once: [`LinkageInfo::parse`] runs per field during 880-linkage
+/// scans, so the pattern must not recompile on every call.
+static LINKAGE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(\d{3})-(\d{2,3})(?:/([\(\$][A-Za-z0-9]))?(?:/r)?$").unwrap());
 
 /// Information extracted from MARC subfield 6 (Linkage).
 ///
@@ -87,17 +101,7 @@ impl LinkageInfo {
     /// `None` if the format is invalid.
     #[must_use]
     pub fn parse(value: &str) -> Option<Self> {
-        // Pattern: TAG-OCC[/SCRIPT][/r]
-        // TAG = 3-digit field tag (e.g., 880, 100, 245)
-        // OCC = 2-3 digit occurrence number (e.g., 01, 02, 001)
-        // SCRIPT = optional MARC script identification code:
-        //   - Parenthesized: (2 (Hebrew), (3 (Arabic), (B (Latin),
-        //     (N (Cyrillic), (S (Greek), (4 (Devanagari), etc.
-        //   - Dollar-sign: $1 (CJK)
-        // /r = optional field orientation (right-to-left)
-        let pattern = Regex::new(r"^(\d{3})-(\d{2,3})(?:/([\(\$][A-Za-z0-9]))?(?:/r)?$").ok()?;
-
-        let caps = pattern.captures(value)?;
+        let caps = LINKAGE_RE.captures(value)?;
 
         let tag = caps.get(1)?.as_str().to_string();
         let occurrence = caps.get(2)?.as_str().to_string();

--- a/src/marcxml.rs
+++ b/src/marcxml.rs
@@ -34,7 +34,9 @@ use crate::record::{Field, Record};
 use quick_xml::events::Event;
 use quick_xml::se::to_string as xml_to_string;
 use quick_xml::{Decoder, XmlVersion};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 
 /// The MARCXML namespace URI.
 const MARCXML_NS: &str = "http://www.loc.gov/MARC21/slim";
@@ -105,21 +107,23 @@ pub struct MarcxmlCollection {
 // Namespace stripping
 // ---------------------------------------------------------------------------
 
+/// `xmlns="..."` / `xmlns:prefix="..."` namespace declarations.
+static RE_XMLNS_DECL: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"\s+xmlns(?::\w+)?="[^"]*""#).unwrap());
+
+/// A namespace prefix on an element name, e.g. `<marc:record>` /
+/// `</marc:record>`.
+static RE_NS_PREFIX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<(/?)(\w+):").unwrap());
+
 /// Strip XML namespace prefixes and declarations from MARCXML input.
 ///
 /// Handles both `marc:record` → `record` (prefixed namespace) and
-/// `xmlns="..."` / `xmlns:marc="..."` (namespace declarations).
+/// `xmlns="..."` / `xmlns:marc="..."` (namespace declarations). The two
+/// patterns are compiled once: this runs per record on the MARCXML
+/// deserialization path.
 fn strip_marcxml_ns(xml: &str) -> String {
-    use regex::Regex;
-
-    // Strip xmlns declarations (both default and prefixed)
-    let re_xmlns = Regex::new(r#"\s+xmlns(?::\w+)?="[^"]*""#).unwrap();
-    let stripped = re_xmlns.replace_all(xml, "");
-
-    // Strip namespace prefixes on element names: <marc:record> → <record>,
-    // </marc:record> → </record>
-    let re_prefix = Regex::new(r"<(/?)(\w+):").unwrap();
-    re_prefix.replace_all(&stripped, "<$1").to_string()
+    let stripped = RE_XMLNS_DECL.replace_all(xml, "");
+    RE_NS_PREFIX.replace_all(&stripped, "<$1").to_string()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
PERF-7 from the v0.8.2 review. Three regexes were compiled on **every call** instead of once:
- `LinkageInfo::parse` (`field_linkage.rs`) — runs per field during 880-linkage scans.
- the two namespace-strip patterns in `strip_marcxml_ns` (`marcxml.rs`) — run per MARCXML record parse.

All three move to module-level `LazyLock<Regex>` statics (the codebase's existing idiom, e.g. `marc8_tables.rs`). The `field_linkage` pattern also drops its `.ok()?` on a literal pattern — a compile error there is now a panic at init, strictly more correct than silently returning `None`.

## Measurement (per epic protocol)

`regex` compilation is expensive — hundreds of µs for these patterns — and `main` paid it twice per MARCXML parse. So the win on the single-record path is large. Apple M4, release, repeated `parse_xml_to_array` on a single-record document, 7×30k, median:

| | main | branch |
|---|------|--------|
| single-record MARCXML parse | 2,747 parse/s | **224,056 parse/s** (~80×) |

Batch/whole-document parsing strips namespaces once per document, so it already amortized this and is unchanged. The headline win is for callers parsing MARCXML records one at a time in a loop. 880-linkage parsing (`get_linked_fields` etc.) gets the same per-call compile eliminated.

## Test

`.cargo/check.sh` green; existing `field_linkage` (21) and `marcxml` (16) test suites pass unchanged. No behavior change — same patterns, compiled once.

Bead: bd-0pg6.7