### PR TITLE
Perf grab bag: get_fields call count, writer digits, read zero-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Record.get_fields()` with no arguments is faster: it made one PyO3 call per control tag
+  (nine) plus one per data field, and now fetches all control fields in a single call.
+  Control fields come back in record order rather than fixed ascending-tag order (a
+  difference only for records whose control fields are stored out of order; record order
+  matches pymarc).
+- Writing ISO 2709 records (`MARCWriter` and the authority/holdings writers) allocates less:
+  each directory entry's length and start-position digits are written straight into the
+  output buffer instead of through a per-field `format!`.
 - MARCXML deserialization and 880-linkage parsing no longer recompile their regexes on
   every call (hoisted to `LazyLock` statics). Parsing MARCXML records one at a time — e.g.
   `parse_xml_to_array` in a loop — is substantially faster; batch/whole-document parsing

--- a/mrrc/__init__.py
+++ b/mrrc/__init__.py
@@ -1021,10 +1021,14 @@ class Record:
         result = []
 
         if not tags:
-            # Return all control fields, then all data fields
-            for tag in _CONTROL_TAGS:
-                for i, value in enumerate(self._inner.control_field_values(tag)):
-                    result.append(_wrap_control_field(self, tag, i, value))
+            # All control fields (one Rust call, not one per control tag),
+            # then all data fields. Repeated control tags yield one field per
+            # value; the per-tag occurrence index is tracked here.
+            control_occ: dict[str, int] = {}
+            for tag, value in self._inner.control_fields():
+                i = control_occ.get(tag, 0)
+                control_occ[tag] = i + 1
+                result.append(_wrap_control_field(self, tag, i, value))
             occurrences: dict[str, int] = {}
             for field in self._inner.fields():
                 i = occurrences.get(field.tag, 0)

--- a/src-python/src/backend.rs
+++ b/src-python/src/backend.rs
@@ -10,7 +10,7 @@ use crate::parse_error::ParseError;
 use mrrc::RecoveryMode;
 use pyo3::prelude::*;
 use std::fs::File;
-use std::io::{BufReader, Cursor, ErrorKind, Read};
+use std::io::{BufReader, Cursor, Read};
 
 /// Buffer capacity for file-path backends. Matches the core readers'
 /// `from_path` buffering: the per-record read loop issues at least two
@@ -269,33 +269,17 @@ impl ReaderBackend {
             );
         }
 
-        // Read remainder of record (record_length - 24 bytes). Use a
-        // manual loop rather than `read_exact` so we can report the
-        // actual bytes-read count when the stream ends short — same
-        // pattern the Rust core uses in `read_record_data`. `read_exact`
-        // doesn't expose partial-read state on EOF, which produced
-        // wrong `actual_length` values on the typed Python exception.
+        // Read remainder of record (record_length - 24 bytes). `take` +
+        // `read_to_end` grows the buffer as bytes arrive — no zero-init
+        // memset per record — retries on `Interrupted` internally, and
+        // reports the actual count when the stream ends short (so the typed
+        // truncation error below carries the right `actual_length`).
         let expected_body_len = record_length - 24;
-        let mut record_data = vec![0u8; expected_body_len];
-        let mut bytes_read = 0usize;
-        loop {
-            match reader.read(&mut record_data[bytes_read..]) {
-                Ok(0) => break,
-                Ok(n) => {
-                    bytes_read += n;
-                    if bytes_read == expected_body_len {
-                        break;
-                    }
-                },
-                Err(e) if e.kind() == ErrorKind::Interrupted => continue,
-                Err(e) => {
-                    return Err(ParseError::io_error(format!(
-                        "Failed to read record data: {}",
-                        e
-                    )));
-                },
-            }
-        }
+        let mut record_data = Vec::with_capacity(expected_body_len);
+        let bytes_read = reader
+            .take(expected_body_len as u64)
+            .read_to_end(&mut record_data)
+            .map_err(|e| ParseError::io_error(format!("Failed to read record data: {}", e)))?;
         if bytes_read != expected_body_len {
             // Truncation: the leader (24 bytes) was read, then the
             // body fell short. In Strict mode this surfaces as a

--- a/src/authority_writer.rs
+++ b/src/authority_writer.rs
@@ -6,7 +6,7 @@
 
 use crate::authority_record::AuthorityRecord;
 use crate::error::{MarcError, Result};
-use crate::iso2709::validate_directory_tag;
+use crate::iso2709::{push_zero_padded, validate_directory_tag};
 use std::io::Write;
 
 const FIELD_TERMINATOR: u8 = 0x1E;
@@ -82,8 +82,8 @@ impl<W: Write> AuthorityMarcWriter<W> {
             // Write directory entry (tag + length + start position)
             let length = data.len() - start_pos;
             directory.extend_from_slice(tag.as_bytes());
-            directory.extend_from_slice(format!("{length:04}").as_bytes());
-            directory.extend_from_slice(format!("{start_pos:05}").as_bytes());
+            push_zero_padded(directory, length, 4);
+            push_zero_padded(directory, start_pos, 5);
 
             Ok(())
         };

--- a/src/holdings_writer.rs
+++ b/src/holdings_writer.rs
@@ -6,7 +6,7 @@
 
 use crate::error::{MarcError, Result};
 use crate::holdings_record::HoldingsRecord;
-use crate::iso2709::validate_directory_tag;
+use crate::iso2709::{push_zero_padded, validate_directory_tag};
 use std::io::Write;
 
 const FIELD_TERMINATOR: u8 = 0x1E;
@@ -82,8 +82,8 @@ impl<W: Write> HoldingsMarcWriter<W> {
             // Write directory entry (tag + length + start position)
             let length = data.len() - start_pos;
             directory.extend_from_slice(tag.as_bytes());
-            directory.extend_from_slice(format!("{length:04}").as_bytes());
-            directory.extend_from_slice(format!("{start_pos:05}").as_bytes());
+            push_zero_padded(directory, length, 4);
+            push_zero_padded(directory, start_pos, 5);
 
             Ok(())
         };

--- a/src/iso2709.rs
+++ b/src/iso2709.rs
@@ -537,6 +537,34 @@ pub fn is_control_field_tag(tag: &str) -> bool {
     tag.len() == 3 && tag.starts_with('0') && tag.chars().all(|c| c.is_ascii_digit()) && tag < "010"
 }
 
+/// Append `value` to `buf` as a zero-padded ASCII decimal of at least
+/// `width` digits, written directly without a heap `format!` allocation.
+///
+/// Used for the ISO 2709 directory's field-length (width 4) and
+/// starting-position (width 5) entries — written once per field by all three
+/// writers. Matches `format!("{value:0width$}")`: a value needing more than
+/// `width` digits is written in full (the directory entry is then malformed,
+/// exactly as the `format!` path was).
+pub(crate) fn push_zero_padded(buf: &mut Vec<u8>, value: usize, width: usize) {
+    const DIGITS: &[u8; 10] = b"0123456789";
+    let mut digits = 1;
+    let mut n = value;
+    while n >= 10 {
+        n /= 10;
+        digits += 1;
+    }
+    let total = digits.max(width);
+    let start = buf.len();
+    buf.resize(start + total, b'0');
+    let mut n = value;
+    let mut i = start + total;
+    while n > 0 {
+        i -= 1;
+        buf[i] = DIGITS[n % 10];
+        n /= 10;
+    }
+}
+
 /// Validate that a field tag fits the ISO 2709 directory's fixed-width
 /// 3-byte tag field. Tags must be exactly 3 ASCII bytes; non-ASCII
 /// characters re-encode to multiple UTF-8 bytes when written and

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -44,7 +44,7 @@
 
 use crate::error::{MarcError, Result};
 use crate::formats::FormatWriter;
-use crate::iso2709::validate_directory_tag;
+use crate::iso2709::{push_zero_padded, validate_directory_tag};
 use crate::record::Record;
 use std::io::Write;
 
@@ -164,8 +164,8 @@ impl<W: Write> MarcWriter<W> {
 
                     // Add directory entry
                     directory.extend_from_slice(tag.as_bytes());
-                    directory.extend_from_slice(format!("{field_length:04}").as_bytes());
-                    directory.extend_from_slice(format!("{current_position:05}").as_bytes());
+                    push_zero_padded(&mut directory, field_length, 4);
+                    push_zero_padded(&mut directory, current_position, 5);
 
                     // Add data
                     data_area.extend_from_slice(field_data);
@@ -194,8 +194,8 @@ impl<W: Write> MarcWriter<W> {
 
                 // Add directory entry
                 directory.extend_from_slice(tag.as_bytes());
-                directory.extend_from_slice(format!("{field_length:04}").as_bytes());
-                directory.extend_from_slice(format!("{current_position:05}").as_bytes());
+                push_zero_padded(&mut directory, field_length, 4);
+                push_zero_padded(&mut directory, current_position, 5);
 
                 // Add data
                 data_area.extend_from_slice(&field_data);


### PR DESCRIPTION
PERF-10 from the v0.8.2 review — the worthwhile micro-optimizations from the grab bag.

## Changes

- **`get_fields()` no-arg → one PyO3 call for control fields.** It made one round-trip per control tag (nine calls to `control_field_values`) plus one per data field. It now calls `control_fields()` **once**. Control fields come back in record order rather than fixed ascending-tag order (only observable for records with out-of-order control fields; record order matches pymarc, and no test pinned the old order — `fields()` delegates to `get_fields()`, the ordering tests filter to data fields).
- **Writer directory digits without `format!`.** The three ISO 2709 writers allocated two `String`s per directory entry (field length, start position). New shared `iso2709::push_zero_padded` writes the fixed-width digits straight into the output buffer — no per-field heap allocation. (Folds cleanly into ARCH-3 later.)
- **No per-record zero-init on the read path.** `read_record_bytes_from_reader` allocated a zeroed body buffer then immediately overwrote it. Now `take().read_to_end()` into a `with_capacity` buffer — no memset, retries on `Interrupted` internally, same truncation semantics.

**Deferred** per the review's own PERF-10 notes: the bytes-extract copy (→ slice parse / PERF-3), streaming XML/CSV (→ ARCH-1), and `Leader.reserved` as `[u8;4]` (→ 1.0 public-API surface).

## Measurement (per epic protocol)

Apple M4, release, 7 runs, median:

| Path | main | branch | Δ |
|------|------|--------|---|
| `get_fields()` no-arg | 673k/s | **1,105k/s** | **+64%**, non-overlapping |
| write record | 658k/s | **749k/s** | **+14%**, non-overlapping |
| read 1k records | 415k/s | 414k/s | neutral |

The read change is structural — the ~1 KB/record memset is sub-noise on M4 (like PERF-4's copy-elimination); it shows up on weaker hardware and under allocator pressure.

## Test

`.cargo/check.sh` green; full suite passes (904 Python + core Rust), incl. the writer roundtrip and `get_fields`/repeated-control-field tests.

Bead: bd-0pg6.10