### PR TITLE
Release the GIL on the parallel-parse and pipeline-wait paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The parallel parse helpers (`parse_batch_parallel` / `parse_batch_parallel_limited`) and the
+  blocking `ProducerConsumerPipeline` reads now release the GIL during the parallel parse and the
+  channel wait, so other Python threads keep running instead of being blocked for the duration.
+  (The parallel helpers now take ownership of the buffer, required for sound GIL release.)
 - `Record.get_fields()` with no arguments is faster: it made one PyO3 call per control tag
   (nine) plus one per data field, and now fetches all control fields in a single call.
   Control fields come back in record order rather than fixed ascending-tag order (a

--- a/src-python/src/producer_consumer_pipeline_wrapper.rs
+++ b/src-python/src/producer_consumer_pipeline_wrapper.rs
@@ -151,14 +151,17 @@ impl PyProducerConsumerPipeline {
     ///
     /// print(f"Processed {record_count} records")
     /// ```
-    pub fn next(&mut self) -> PyResult<Option<PyRecord>> {
+    pub fn next(&mut self, py: Python<'_>) -> PyResult<Option<PyRecord>> {
         let pipeline = self
             .inner
             .as_ref()
             .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Pipeline closed"))?;
 
-        let record = pipeline
-            .next()
+        // Release the GIL while blocked on the channel recv — the producer runs
+        // in a background OS thread, so holding the GIL here would starve every
+        // other Python thread for the duration of the wait.
+        let record = py
+            .detach(|| pipeline.next())
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
         Ok(record.map(PyRecord::from))
@@ -189,13 +192,14 @@ impl PyProducerConsumerPipeline {
     /// Get the next record in iteration.
     ///
     /// Implements the iterator protocol for use with `for` loops.
-    pub fn __next__(slf: PyRefMut<'_, Self>) -> PyResult<PyRecord> {
-        let pipeline = slf
+    pub fn __next__(&mut self, py: Python<'_>) -> PyResult<PyRecord> {
+        let pipeline = self
             .inner
             .as_ref()
             .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Pipeline closed"))?;
 
-        match pipeline.next() {
+        // Release the GIL while blocked on the recv (see `next`).
+        match py.detach(|| pipeline.next()) {
             Ok(Some(record)) => Ok(PyRecord::from(record)),
             Ok(None) => Err(PyErr::new::<PyStopIteration, _>("EOF")),
             Err(e) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(

--- a/src-python/src/rayon_parser_pool_wrapper.rs
+++ b/src-python/src/rayon_parser_pool_wrapper.rs
@@ -45,16 +45,22 @@ use pyo3::prelude::*;
 /// ```
 #[pyfunction]
 pub fn parse_batch_parallel(
-    _py: Python<'_>,
+    py: Python<'_>,
     boundaries: Vec<(usize, usize)>,
-    buffer: &[u8],
+    buffer: Vec<u8>,
 ) -> PyResult<Vec<PyRecord>> {
-    // Call the Rust implementation
-    let records = rayon_parser_pool::parse_batch_parallel(&boundaries, buffer).map_err(|e| {
-        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Parse error: {}", e))
-    })?;
+    // Release the GIL for the Rayon parallel parse so other Python threads can
+    // run — otherwise the whole point (parallelism) is defeated. `buffer` is an
+    // owned `Vec<u8>` (copied at extraction), not a borrow into Python memory:
+    // a borrowed `&[u8]` into a `bytearray` could be mutated or freed by another
+    // thread while the GIL is released, which would be unsound here.
+    let records = py
+        .detach(|| rayon_parser_pool::parse_batch_parallel(&boundaries, &buffer).map_err(Box::new))
+        .map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Parse error: {}", e))
+        })?;
 
-    // Convert Rust records to PyRecord wrappers (GIL already held)
+    // Convert Rust records to PyRecord wrappers (GIL re-acquired after detach)
     Ok(records.into_iter().map(PyRecord::from).collect())
 }
 
@@ -89,17 +95,22 @@ pub fn parse_batch_parallel(
 /// ```
 #[pyfunction]
 pub fn parse_batch_parallel_limited(
-    _py: Python<'_>,
+    py: Python<'_>,
     boundaries: Vec<(usize, usize)>,
-    buffer: &[u8],
+    buffer: Vec<u8>,
     limit: usize,
 ) -> PyResult<Vec<PyRecord>> {
-    // Call the Rust implementation
-    let records = rayon_parser_pool::parse_batch_parallel_limited(&boundaries, buffer, limit)
+    // Release the GIL for the parallel parse (see `parse_batch_parallel` for
+    // why `buffer` must be owned, not a borrow into Python memory).
+    let records = py
+        .detach(|| {
+            rayon_parser_pool::parse_batch_parallel_limited(&boundaries, &buffer, limit)
+                .map_err(Box::new)
+        })
         .map_err(|e| {
             PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Parse error: {}", e))
         })?;
 
-    // Convert to PyRecord (GIL already held)
+    // Convert to PyRecord (GIL re-acquired after detach)
     Ok(records.into_iter().map(PyRecord::from).collect())
 }


### PR DESCRIPTION
PERF-8 (the GIL-holds half). Two parallel-path entry points held the GIL during work that should release it — defeating the parallelism they exist for.

## Changes

- **`parse_batch_parallel` / `parse_batch_parallel_limited`** ran the *entire* Rayon parallel parse with the GIL held. Now wrapped in `py.detach`. The `buffer` param changes from `&[u8]` to an owned `Vec<u8>`: a borrowed slice into a Python `bytearray` could be mutated or freed by another thread while the GIL is released, so the data must be owned before detaching. No Python-API change — both still accept `bytes`/`bytearray`.
- **`ProducerConsumerPipeline.next` / `__next__`** blocked on the channel `recv()` while holding the GIL, starving every other Python thread for the duration of the wait (the producer is a background OS thread). Now detach around the blocking `recv`. `try_next` is left as-is — it's non-blocking, so detaching a `try_recv` would be pure GIL release/re-acquire overhead.

`ProducerConsumerPipeline` is `Send + Sync` (crossbeam `Receiver` + `JoinHandle`), so `&pipeline` is sound inside the detach closure; the parse error is boxed inside the closure to satisfy `result_large_err` (the codebase idiom).

## Deferred

The **per-record channel sends** (PERF-8's other half) are deferred to **bd-yfxy**: secondary (1000-capacity channel, cheap crossbeam sends) and a riskier backpressure/consumer refactor not worth landing in a release PR.

## Measurement

The win is multi-threaded. A pure-Python counter thread running concurrently with 2s of parallel parsing (`mrrc.parse_batch_parallel` in a loop), Apple M4, release:

| | main (GIL held) | branch (GIL released) |
|---|---|---|
| concurrent Python iterations / 2s | 37.4M | **65.3M** (+74%) |

The concurrent thread now runs *during* the parse, not just between calls. Core contention from the internal Rayon parallelism caps the gain in this microbench; the full multi-thread throughput procedure is **bd-ieoe**, which this PR unblocks. Single-thread is neutral-to-slightly-slower from the buffer copy (these helpers are for multi-threaded use).

## Test

`.cargo/check.sh` green; full suite passes (904 Python + core Rust), incl. the 23 pipeline/parallel/rayon tests.

Bead: bd-0pg6.8