### PR TITLE
Thread the owned tag into the field instead of re-allocating it

### DIFF
--- a/src/authority_reader.rs
+++ b/src/authority_reader.rs
@@ -274,8 +274,8 @@ impl Iso2709Builder for AuthorityBuilder {
         self.record.add_control_field(tag, value);
     }
 
-    fn add_data_field(&mut self, tag: String, field: Field) {
-        match tag.as_str() {
+    fn add_data_field(&mut self, field: Field) {
+        match field.tag.as_str() {
             // 1XX — the main heading
             "100" | "110" | "111" | "130" | "148" | "150" | "151" | "155" => {
                 self.record.set_heading(field);

--- a/src/holdings_reader.rs
+++ b/src/holdings_reader.rs
@@ -258,8 +258,8 @@ impl Iso2709Builder for HoldingsBuilder {
         self.record.add_control_field(tag, value);
     }
 
-    fn add_data_field(&mut self, tag: String, field: Field) {
-        match tag.as_str() {
+    fn add_data_field(&mut self, field: Field) {
+        match field.tag.as_str() {
             "852" => self.record.add_location(field),
             "853" => self.record.add_captions_basic(field),
             "854" => self.record.add_captions_supplements(field),

--- a/src/iso2709.rs
+++ b/src/iso2709.rs
@@ -800,7 +800,7 @@ impl DataFieldParseConfig {
 #[inline(always)]
 pub fn parse_data_field(
     field_data: &[u8],
-    tag: &str,
+    tag: String,
     config: DataFieldParseConfig,
     ctx: &ParseContext,
 ) -> Result<Field> {
@@ -822,7 +822,7 @@ pub fn parse_data_field(
         }
         // Per-tag MARC 21 indicator semantics (e.g., 245 ind1 must be 0/1).
         // Tags without rules are accepted as-is.
-        if let Some(rules) = marc21_indicator_validator().get_rules(tag) {
+        if let Some(rules) = marc21_indicator_validator().get_rules(&tag) {
             if !rules.indicator1.is_valid(i1 as char) {
                 return Err(ctx.err_invalid_indicator(0, &[i1], rules.indicator1.expected_human()));
             }
@@ -831,7 +831,10 @@ pub fn parse_data_field(
             }
         }
     }
-    let mut field = Field::new(tag.to_string(), i1 as char, i2 as char);
+    // Move the already-owned tag into the field instead of re-allocating; the
+    // skeleton's directory-walk tag is no longer needed after this call (data
+    // builders read the tag from `field.tag`).
+    let mut field = Field::new(tag, i1 as char, i2 as char);
     let subfields = parse_subfields(&field_data[2..], config, ctx)?;
     field.subfields = subfields;
     Ok(field)

--- a/src/iso2709_skeleton.rs
+++ b/src/iso2709_skeleton.rs
@@ -95,9 +95,10 @@ pub trait Iso2709Builder: Sized {
     fn add_control_field(&mut self, tag: String, value: String);
 
     /// File a parsed data field (non-00X tag) into the in-progress output.
-    /// Authority and holdings dispatch by tag here to organize fields by
-    /// their functional role (heading, tracings, locations, captions, etc.).
-    fn add_data_field(&mut self, tag: String, field: Field);
+    /// Authority and holdings dispatch by tag here (read from `field.tag`) to
+    /// organize fields by their functional role (heading, tracings, locations,
+    /// captions, etc.).
+    fn add_data_field(&mut self, field: Field);
 
     /// Decode a control field's bytes into its string value. The
     /// default strips the trailing `FIELD_TERMINATOR` byte and dispatches
@@ -619,11 +620,11 @@ fn parse_record_body<B: Iso2709Builder>(
                         ctx.stream_byte_offset = record_data_offset + data_start + start_position;
                         if let Ok(field) = parse_data_field(
                             field_data,
-                            &tag,
+                            tag,
                             B::parse_config(validation_level),
                             ctx,
                         ) {
-                            builder.add_data_field(tag, field);
+                            builder.add_data_field(field);
                         }
                         ctx.current_field_tag = None;
                     }
@@ -680,11 +681,12 @@ fn parse_record_body<B: Iso2709Builder>(
             continue;
         }
 
-        // Data field.
-        let parsed = parse_data_field(field_data, &tag, B::parse_config(validation_level), ctx);
+        // Data field. Move the owned tag into the parser (and thence the
+        // field) rather than re-allocating it there.
+        let parsed = parse_data_field(field_data, tag, B::parse_config(validation_level), ctx);
         ctx.current_field_tag = None;
         match parsed {
-            Ok(field) => builder.add_data_field(tag, field),
+            Ok(field) => builder.add_data_field(field),
             Err(e) => {
                 if recovery_mode == RecoveryMode::Strict {
                     return Err(e);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -424,7 +424,7 @@ impl Iso2709Builder for BibBuilder {
     }
 
     #[inline]
-    fn add_data_field(&mut self, _tag: String, field: Field) {
+    fn add_data_field(&mut self, field: Field) {
         self.record.add_field(field);
     }
 


### PR DESCRIPTION
PERF-9, the **short-term** half (the long-term `Tag([u8;3])` newtype stays deferred in **bd-xjws** under the d7aq/1.0 epic).

## What changed

The directory walk allocated a tag `String` per entry; `parse_data_field` then allocated it *again* for the `Field` (`tag.to_string()`); and the skeleton's copy was discarded by the bibliographic builder (the `_tag` param) or used-then-dropped by authority/holdings.

- `parse_data_field` now takes the **owned** tag `String` and moves it into the `Field` — no re-allocation.
- The `Iso2709Builder::add_data_field` trait method drops its `tag` parameter; the authority and holdings builders dispatch on `field.tag` instead of a separate `String`.

Net: **one tag allocation per data field eliminated** across all three readers (bib/authority/holdings). No API change, no behavior change.

## Measurement

Apple M4, release, `MARCReader(path)` read, 7 runs, median rec/s:

| Corpus | main | branch | Δ |
|--------|------|--------|---|
| 10k | 406k | 411k | +1% (within noise) |
| 100k | 405k | 425k | +5% |

Structural allocator-pressure reduction — modest wall-clock on M4's memory bandwidth, growing at scale (same shape as PERF-4's copy-elimination). This parse path **is** covered by the CodSpeed read benchmarks (`read_1k`/`read_10k` in `marc_benchmarks`), so the per-field allocation drop should show as an instruction-count reduction there — the durable regression signal.

## Test

`.cargo/check.sh` green; full suite passes (904 Python + core Rust), incl. the bibliographic, authority, and holdings reader roundtrip tests (the authority/holdings dispatch now reads `field.tag`).

Bead: bd-0pg6.9