### PR TITLE
Harden scheduled-CI jobs and record the check.sh semver gap

### DIFF
--- a/.cargo/check.sh
+++ b/.cargo/check.sh
@@ -2,6 +2,10 @@
 
 # Local CI-equivalent checks
 # Run before pushing to match GitHub Actions lint.yml
+#
+# Note: cargo-semver-checks runs in CI only (it needs a published crate
+# baseline and is heavier than the other gates here). It is deliberately
+# omitted from this script.
 
 set -e
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -57,7 +57,7 @@ jobs:
   notify-failure:
     name: File failure issue
     needs: security-audit
-    if: failure() && github.event_name == 'schedule'
+    if: (failure() || cancelled()) && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -138,7 +138,7 @@ jobs:
   notify-failure:
     name: File failure issue
     needs: [coverage-rust, coverage-python]
-    if: failure() && github.event_name == 'schedule'
+    if: (failure() || cancelled()) && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -110,7 +110,7 @@ jobs:
   notify-failure:
     name: File failure issue
     needs: fuzz
-    if: failure() && github.event_name == 'schedule'
+    if: (failure() || cancelled()) && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/memory-safety.yml
+++ b/.github/workflows/memory-safety.yml
@@ -53,7 +53,7 @@ jobs:
   notify-failure:
     name: File failure issue
     needs: asan-library-tests
-    if: failure() && github.event_name == 'schedule'
+    if: (failure() || cancelled()) && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -15,7 +15,7 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6.0.3
 
@@ -37,7 +37,7 @@ jobs:
   notify-failure:
     name: File failure issue
     needs: miri
-    if: failure() && github.event_name == 'schedule'
+    if: (failure() || cancelled()) && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Python bindings via PyO3/maturin.
 ## Build & Test
 
 ```bash
-# Full pre-push check (~30s) — always run this before pushing
+# Full pre-push check (~30s warm cache; cold builds take longer) — always run this before pushing
 .cargo/check.sh
 
 # Quick mode (skips docs, audit, maturin rebuild)


### PR DESCRIPTION
## Summary

- **Notify gates now fire on cancel as well as failure** (bd-h66p): `timeout-minutes` kills yield conclusion `cancelled`, not `failure`, so the old `if: failure() && github.event_name == 'schedule'` guard silently dropped timeout notifications. All 5 scheduled workflows (`audit.yml`, `coverage.yml`, `fuzz.yml`, `memory-safety.yml`, `miri.yml`) updated to `if: (failure() || cancelled()) && github.event_name == 'schedule'`.
- **Miri timeout raised 60→90 min** (bd-hjv0, stopgap only): genuine Miri runs were finishing at 59-61 minutes and being killed by the job budget. This PR raises the budget as a stopgap. The durable fix — scoping Miri to the unsafe/FFI surface — is deliberately deferred and remains tracked in bd-hjv0.
- **Miri rust-cache rotating key** (bd-me8m): inspection shows the `$DATE` rotating cache key described in bd-me8m was already removed in PR #311 ("cache unification"). The current `Swatinem/rust-cache@v2` step carries no custom key and correctly derives its own from `Cargo.lock`. No further change needed; this PR closes the bead.
- **Document the semver-checks gap and fix the stale timing claim** (bd-g4tn): added a comment to `.cargo/check.sh`'s header recording that `cargo-semver-checks` runs in CI only (it needs a published crate baseline and is heavier than the other local gates). Also qualified the "~30s" claim in `CLAUDE.md` to "~30s warm cache; cold builds take longer".

## Test plan

- YAML parse: `uv run python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))"` passed on all 5 edited workflow files
- `.cargo/check.sh` passed (full run, pre-commit and pre-push hooks both green; `✓ All checks passed`)
- `.beads/issues.jsonl` not committed (discarded with `git checkout -- .beads/issues.jsonl` before staging)

Beads: bd-h66p, bd-me8m, bd-g4tn, bd-hjv0 (stopgap only)