### PR TITLE
Bring the mrrc-python bindings crate under the workspace lint regime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,13 +122,15 @@ toml = "1.1"
 anyhow = "1.0"
 flate2 = "1.0"
 
-# Lint configuration following Rust API Guidelines
-[lints.rust]
+# Lint configuration following Rust API Guidelines. Defined at the workspace
+# level so both the core crate and the mrrc-python bindings crate inherit one
+# regime — each opts in with `[lints]\nworkspace = true`.
+[workspace.lints.rust]
 unsafe_code = "deny"
 missing_docs = "warn"
 missing_debug_implementations = "warn"
 
-[lints.clippy]
+[workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 # Restrict to reasonable cognitive complexity
@@ -139,6 +141,10 @@ module_name_repetitions = "allow"
 similar_names = "allow"
 # Type complexity is managed separately
 type_complexity = "allow"
+
+# The mrrc core crate inherits the workspace lints.
+[lints]
+workspace = true
 
 # Targets that exercise the BIBFRAME module are skipped when the
 # `bibframe` feature is off (e.g. the --no-default-features check).

--- a/src-python/Cargo.toml
+++ b/src-python/Cargo.toml
@@ -7,6 +7,8 @@ authors.workspace = true
 description = "PyO3 bindings for the mrrc MARC library"
 license.workspace = true
 repository.workspace = true
+# Bindings crate: built only as the `_mrrc` extension, never published to crates.io.
+publish = false
 
 [dependencies]
 pyo3 = { version = "0.29", features = ["extension-module"] }
@@ -22,3 +24,7 @@ smallvec = { workspace = true }
 [lib]
 name = "_mrrc"
 crate-type = ["cdylib"]
+
+# Inherit the shared workspace lint regime (see the root Cargo.toml).
+[lints]
+workspace = true

--- a/src-python/src/authority_readers.rs
+++ b/src-python/src/authority_readers.rs
@@ -20,14 +20,16 @@ enum AuthorityReaderBackend {
     PythonFile(Py<PyAny>),
 }
 
-/// Python wrapper for AuthorityMarcReader
+/// Python wrapper for `AuthorityMarcReader`
 ///
 /// Reads MARC Authority records (Type Z) from different sources with automatic
 /// backend selection:
-/// - File paths → RustFile (parallel-safe)
-/// - Bytes/BytesIO → CursorBackend (parallel-safe)
-/// - Python file objects → PythonFile (requires GIL)
+/// - File paths → `RustFile` (parallel-safe)
+/// - Bytes/BytesIO → `CursorBackend` (parallel-safe)
+/// - Python file objects → `PythonFile` (requires GIL)
 #[pyclass(name = "AuthorityMARCReader")]
+// wraps AuthorityReaderBackend which does not implement Debug
+#[allow(missing_debug_implementations)]
 pub struct PyAuthorityMARCReader {
     backend: Option<AuthorityReaderBackend>,
     recovery_mode: RecoveryMode,
@@ -36,7 +38,7 @@ pub struct PyAuthorityMARCReader {
 
 #[pymethods]
 impl PyAuthorityMARCReader {
-    /// Create a new AuthorityMARCReader
+    /// Create a new `AuthorityMARCReader`
     ///
     /// # Arguments
     /// * `source` - File path (str), pathlib.Path, bytes, or file-like object
@@ -45,7 +47,7 @@ impl PyAuthorityMARCReader {
     ///   permissive for pymarc-shape parity; the Rust core defaults
     ///   to strict for explicit-error-handling parity with Rust idiom.
     /// * `validation_level` - What counts as an error during parsing:
-    ///   'structural' (default) or 'strict_marc'.
+    ///   'structural' (default) or '`strict_marc`'.
     #[new]
     #[pyo3(signature = (source, *, recovery_mode = "permissive", validation_level = "structural"))]
     pub fn new(

--- a/src-python/src/backend.rs
+++ b/src-python/src/backend.rs
@@ -1,9 +1,9 @@
-//! Backend abstraction for ReaderBackend enum
+//! Backend abstraction for `ReaderBackend` enum
 //!
 //! This module provides a unified interface for different input sources:
-//! - `RustFile`: Direct file I/O via std::fs::File
-//! - `CursorBackend`: In-memory reads from bytes via std::io::Cursor
-//! - `PythonFile`: Python file-like objects (calls .read() method)
+//! - `RustFile`: Direct file I/O via `std::fs::File`
+//! - `CursorBackend`: In-memory reads from bytes via `std::io::Cursor`
+//! - `PythonFile`: Python file-like objects (calls .`read()` method)
 
 use crate::chunked_py_reader::ChunkedPyFileReader;
 use crate::parse_error::ParseError;
@@ -45,9 +45,9 @@ impl RecordByteSource for ReaderBackend {
 /// Unified backend interface for reading MARC records from different sources
 ///
 /// Supports 8 input types:
-/// - str, pathlib.Path → RustFile
-/// - bytes, bytearray → CursorBackend
-/// - file object, BytesIO, socket.socket → PythonFile
+/// - str, pathlib.Path → `RustFile`
+/// - bytes, bytearray → `CursorBackend`
+/// - file object, `BytesIO`, socket.socket → `PythonFile`
 ///
 /// The backend carries the active [`RecoveryMode`] so that short body
 /// reads can route to either a fatal `TruncatedRecord` (strict) or a
@@ -62,31 +62,31 @@ pub struct ReaderBackend {
 
 #[derive(Debug)]
 enum BackendKind {
-    /// Buffered file I/O via std::fs::File
+    /// Buffered file I/O via `std::fs::File`
     /// Input: str path or pathlib.Path
     RustFile(BufReader<File>),
 
-    /// In-memory reads from bytes via std::io::Cursor
+    /// In-memory reads from bytes via `std::io::Cursor`
     /// Input: bytes or bytearray
     /// Enables thread-safe parallel parsing without Python interaction
     CursorBackend(Cursor<Vec<u8>>),
 
     /// Python file-like object (fallback for custom types)
-    /// Input: Any object with .read() method
+    /// Input: Any object with .`read()` method
     /// Reads in large chunks and slices records out in Rust; the GIL is
     /// held only while a chunk is being read, not per record.
     PythonFile(ChunkedPyFileReader),
 }
 
 impl ReaderBackend {
-    /// Create a ReaderBackend from a Python object
+    /// Create a `ReaderBackend` from a Python object
     ///
     /// Type detection order:
-    /// 1. str → RustFile
-    /// 2. pathlib.Path → RustFile
-    /// 3. bytes/bytearray → CursorBackend
-    /// 4. Object with .read() method → PythonFile
-    /// 5. Unknown type → TypeError
+    /// 1. str → `RustFile`
+    /// 2. pathlib.Path → `RustFile`
+    /// 3. bytes/bytearray → `CursorBackend`
+    /// 4. Object with .`read()` method → `PythonFile`
+    /// 5. Unknown type → `TypeError`
     ///
     /// # Arguments
     /// * `source` - Python object (str, Path, bytes, bytearray, or file-like)
@@ -94,8 +94,8 @@ impl ReaderBackend {
     ///
     /// # Errors
     /// - `TypeError` if input type is not supported
-    /// - `FileNotFoundError` if file path doesn't exist (RustFile)
-    /// - `IOError` if file cannot be opened (RustFile)
+    /// - `FileNotFoundError` if file path doesn't exist (`RustFile`)
+    /// - `IOError` if file cannot be opened (`RustFile`)
     pub fn from_python(
         source: &Bound<'_, PyAny>,
         _py: Python,
@@ -121,19 +121,16 @@ impl ReaderBackend {
                 ))),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
-                        "No such file or directory: '{}'",
-                        path_str
+                        "No such file or directory: '{path_str}'"
                     )))
                 },
                 Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
                     Err(pyo3::exceptions::PyPermissionError::new_err(format!(
-                        "Permission denied: '{}'",
-                        path_str
+                        "Permission denied: '{path_str}'"
                     )))
                 },
                 Err(e) => Err(pyo3::exceptions::PyIOError::new_err(format!(
-                    "Failed to open file '{}': {}",
-                    path_str, e
+                    "Failed to open file '{path_str}': {e}"
                 ))),
             };
         }
@@ -152,19 +149,16 @@ impl ReaderBackend {
                 ))),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
-                        "No such file or directory: '{}'",
-                        path_str
+                        "No such file or directory: '{path_str}'"
                     )))
                 },
                 Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
                     Err(pyo3::exceptions::PyPermissionError::new_err(format!(
-                        "Permission denied: '{}'",
-                        path_str
+                        "Permission denied: '{path_str}'"
                     )))
                 },
                 Err(e) => Err(pyo3::exceptions::PyIOError::new_err(format!(
-                    "Failed to open file '{}': {}",
-                    path_str, e
+                    "Failed to open file '{path_str}': {e}"
                 ))),
             };
         }
@@ -189,11 +183,10 @@ impl ReaderBackend {
         // 5. Unknown type - fail fast with descriptive error
         let type_name = source.get_type().name()?;
         Err(pyo3::exceptions::PyTypeError::new_err(format!(
-            "Unsupported input type: {}. Supported types: str (file path), pathlib.Path, \
+            "Unsupported input type: {type_name}. Supported types: str (file path), pathlib.Path, \
              bytes, bytearray, or file-like object (with .read() method). \
              Examples: 'records.mrc', Path('records.mrc'), b'binary data', \
-             open('records.mrc', 'rb'), io.BytesIO(data), socket.socket(...)",
-            type_name
+             open('records.mrc', 'rb'), io.BytesIO(data), socket.socket(...)"
         )))
     }
 
@@ -208,11 +201,11 @@ impl ReaderBackend {
 
     /// Read the next MARC record from this backend
     ///
-    /// For RustFile and CursorBackend: reads directly without GIL
-    /// For PythonFile: requires GIL to call .read()
+    /// For `RustFile` and `CursorBackend`: reads directly without GIL
+    /// For `PythonFile`: requires GIL to call .`read()`
     ///
     /// # Arguments
-    /// * `py` - Python interpreter handle (required for PythonFile)
+    /// * `py` - Python interpreter handle (required for `PythonFile`)
     ///
     /// # Returns
     /// - `Ok(Some(bytes))` - Successfully read record bytes
@@ -233,7 +226,7 @@ impl ReaderBackend {
         }
     }
 
-    /// Internal helper: Read record bytes from any std::io::Read implementation
+    /// Internal helper: Read record bytes from any `std::io::Read` implementation
     fn read_record_bytes_from_reader<R: Read>(
         reader: &mut R,
         recovery_mode: RecoveryMode,
@@ -247,8 +240,7 @@ impl ReaderBackend {
             },
             Err(e) => {
                 return Err(ParseError::io_error(format!(
-                    "Failed to read record leader: {}",
-                    e
+                    "Failed to read record leader: {e}"
                 )));
             },
         }
@@ -279,7 +271,7 @@ impl ReaderBackend {
         let bytes_read = reader
             .take(expected_body_len as u64)
             .read_to_end(&mut record_data)
-            .map_err(|e| ParseError::io_error(format!("Failed to read record data: {}", e)))?;
+            .map_err(|e| ParseError::io_error(format!("Failed to read record data: {e}")))?;
         if bytes_read != expected_body_len {
             // Truncation: the leader (24 bytes) was read, then the
             // body fell short. In Strict mode this surfaces as a

--- a/src-python/src/batched_reader.rs
+++ b/src-python/src/batched_reader.rs
@@ -90,7 +90,7 @@ impl<S: RecordByteSource> BatchedReader<S> {
         }
     }
 
-    /// Backend kind for diagnostics ("rust_file" | "cursor" | "python_file").
+    /// Backend kind for diagnostics ("`rust_file`" | "cursor" | "`python_file`").
     pub fn backend_kind(&self) -> &'static str {
         self.source.backend_kind()
     }

--- a/src-python/src/bibframe.rs
+++ b/src-python/src/bibframe.rs
@@ -34,14 +34,14 @@ use pyo3::prelude::*;
 /// config.set_authority_linking(True)
 /// ```
 #[pyclass(name = "BibframeConfig", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PyBibframeConfig {
     pub(crate) inner: BibframeConfig,
 }
 
 #[pymethods]
 impl PyBibframeConfig {
-    /// Create a new BibframeConfig with default settings.
+    /// Create a new `BibframeConfig` with default settings.
     #[new]
     fn new() -> Self {
         Self {
@@ -75,7 +75,7 @@ impl PyBibframeConfig {
     /// * `format` - One of: "rdf-xml", "jsonld", "turtle", "ntriples"
     ///
     /// # Raises
-    /// ValueError: If format is not recognized
+    /// `ValueError`: If format is not recognized
     fn set_output_format(&mut self, format: &str) -> PyResult<()> {
         self.inner.output_format = parse_rdf_format(format)?;
         Ok(())
@@ -200,6 +200,7 @@ impl PyBibframeConfig {
 /// ntriples = graph.serialize("ntriples")
 /// ```
 #[pyclass(name = "RdfGraph")]
+#[derive(Debug)]
 pub struct PyRdfGraph {
     pub(crate) inner: RdfGraph,
 }
@@ -233,7 +234,7 @@ impl PyRdfGraph {
     /// The serialized RDF as a string
     ///
     /// # Raises
-    /// ValueError: If format is not recognized or serialization fails
+    /// `ValueError`: If format is not recognized or serialization fails
     fn serialize(&self, format: &str) -> PyResult<String> {
         let rdf_format = parse_rdf_format(format)?;
         self.inner
@@ -248,10 +249,10 @@ impl PyRdfGraph {
     /// * `format` - One of: "rdf-xml", "jsonld", "turtle", "ntriples"
     ///
     /// # Returns
-    /// A new RdfGraph instance
+    /// A new `RdfGraph` instance
     ///
     /// # Raises
-    /// ValueError: If format is not recognized or parsing fails
+    /// `ValueError`: If format is not recognized or parsing fails
     #[staticmethod]
     fn parse(data: &str, format: &str) -> PyResult<PyRdfGraph> {
         let rdf_format = parse_rdf_format(format)?;
@@ -262,7 +263,7 @@ impl PyRdfGraph {
     /// Get all triples as a list of (subject, predicate, object) tuples.
     ///
     /// # Returns
-    /// A list of tuples where each tuple is (subject_str, predicate_str, object_str)
+    /// A list of tuples where each tuple is (`subject_str`, `predicate_str`, `object_str`)
     fn triples(&self) -> Vec<(String, String, String)> {
         self.inner
             .triples()
@@ -291,7 +292,7 @@ impl PyRdfGraph {
 /// * `config` - Configuration options for the conversion
 ///
 /// # Returns
-/// An RdfGraph containing the BIBFRAME representation
+/// An `RdfGraph` containing the BIBFRAME representation
 ///
 /// # Example
 ///
@@ -328,7 +329,7 @@ pub fn py_marc_to_bibframe(record: &PyRecord, config: &PyBibframeConfig) -> PyRd
 /// A MARC Record representing the BIBFRAME data
 ///
 /// # Raises
-/// ValueError: If the graph cannot be converted
+/// `ValueError`: If the graph cannot be converted
 ///
 /// # Example
 ///
@@ -356,28 +357,27 @@ fn parse_rdf_format(format: &str) -> PyResult<RdfFormat> {
         "turtle" | "ttl" | "text/turtle" => Ok(RdfFormat::Turtle),
         "ntriples" | "nt" | "n-triples" | "application/n-triples" => Ok(RdfFormat::NTriples),
         _ => Err(PyValueError::new_err(format!(
-            "Unknown RDF format: '{}'. Use one of: rdf-xml, jsonld, turtle, ntriples",
-            format
+            "Unknown RDF format: '{format}'. Use one of: rdf-xml, jsonld, turtle, ntriples"
         ))),
     }
 }
 
-/// Convert an RdfNode to a string representation.
+/// Convert an `RdfNode` to a string representation.
 fn node_to_string(node: &RdfNode) -> String {
     match node {
-        RdfNode::Uri(uri) => format!("<{}>", uri),
-        RdfNode::BlankNode(id) => format!("_:{}", id),
+        RdfNode::Uri(uri) => format!("<{uri}>"),
+        RdfNode::BlankNode(id) => format!("_:{id}"),
         RdfNode::Literal {
             value,
             language,
             datatype,
         } => {
             if let Some(lang) = language {
-                format!("\"{}\"@{}", value, lang)
+                format!("\"{value}\"@{lang}")
             } else if let Some(dt) = datatype {
-                format!("\"{}\"^^<{}>", value, dt)
+                format!("\"{value}\"^^<{dt}>")
             } else {
-                format!("\"{}\"", value)
+                format!("\"{value}\"")
             }
         },
     }

--- a/src-python/src/boundary_scanner_wrapper.rs
+++ b/src-python/src/boundary_scanner_wrapper.rs
@@ -1,4 +1,4 @@
-//! Python wrapper for the Rust RecordBoundaryScanner.
+//! Python wrapper for the Rust `RecordBoundaryScanner`.
 //!
 //! This module provides Python bindings to the Rust `RecordBoundaryScanner` for
 //! efficient MARC record boundary detection using SIMD-accelerated memchr.
@@ -6,7 +6,7 @@
 use mrrc::boundary_scanner::RecordBoundaryScanner as RustBoundaryScanner;
 use pyo3::prelude::*;
 
-/// Python wrapper for RecordBoundaryScanner.
+/// Python wrapper for `RecordBoundaryScanner`.
 ///
 /// Scans MARC record boundaries by detecting 0x1E delimiters in binary data.
 /// Returns (offset, length) tuples for each complete record found.
@@ -25,13 +25,14 @@ use pyo3::prelude::*;
 ///     # Process record_bytes...
 /// ```
 #[pyclass(name = "RecordBoundaryScanner")]
+#[derive(Debug)]
 pub struct PyRecordBoundaryScanner {
     inner: RustBoundaryScanner,
 }
 
 #[pymethods]
 impl PyRecordBoundaryScanner {
-    /// Create a new RecordBoundaryScanner.
+    /// Create a new `RecordBoundaryScanner`.
     ///
     /// The scanner uses SIMD-accelerated memchr for efficient boundary detection.
     #[new]

--- a/src-python/src/chunked_py_reader.rs
+++ b/src-python/src/chunked_py_reader.rs
@@ -77,30 +77,27 @@ impl ChunkedPyFileReader {
                 .read_method
                 .bind(py)
                 .call1((CHUNK_SIZE,))
-                .map_err(|e| ParseError::io_error(format!("Python read() failed: {}", e)))?;
+                .map_err(|e| ParseError::io_error(format!("Python read() failed: {e}")))?;
 
             // Fast path: a `bytes` return is borrowed and copied once into
             // the buffer. `bytearray`/other buffer types fall back to an
             // owned extract so custom file-likes keep working.
-            match result.cast::<PyBytes>() {
-                Ok(py_bytes) => {
-                    let slice = py_bytes.as_bytes();
-                    if slice.is_empty() {
-                        self.eof = true;
-                        break;
-                    }
-                    self.buffer.extend_from_slice(slice);
-                },
-                Err(_) => {
-                    let owned: Vec<u8> = result.extract().map_err(|_| {
-                        ParseError::invalid_record("read() must return bytes".to_string())
-                    })?;
-                    if owned.is_empty() {
-                        self.eof = true;
-                        break;
-                    }
-                    self.buffer.extend_from_slice(&owned);
-                },
+            if let Ok(py_bytes) = result.cast::<PyBytes>() {
+                let slice = py_bytes.as_bytes();
+                if slice.is_empty() {
+                    self.eof = true;
+                    break;
+                }
+                self.buffer.extend_from_slice(slice);
+            } else {
+                let owned: Vec<u8> = result.extract().map_err(|_| {
+                    ParseError::invalid_record("read() must return bytes".to_string())
+                })?;
+                if owned.is_empty() {
+                    self.eof = true;
+                    break;
+                }
+                self.buffer.extend_from_slice(&owned);
             }
         }
         Ok(())
@@ -129,8 +126,7 @@ impl ChunkedPyFileReader {
             // backend.rs Python path's "Incomplete leader" error.
             let near = &self.buffer[self.pos..];
             return Err(ParseError::invalid_record(format!(
-                "Incomplete leader: expected 24 bytes, got {}",
-                avail
+                "Incomplete leader: expected 24 bytes, got {avail}"
             ))
             .with_bytes_near(near, 0));
         }

--- a/src-python/src/error.rs
+++ b/src-python/src/error.rs
@@ -93,15 +93,12 @@ fn describe<'py>(py: Python<'py>, err: &MarcError) -> PyResult<(&'static str, Bo
         Some(bytes) => kwargs.set_item("found", PyBytes::new(py, bytes))?,
         None => kwargs.set_item("found", py.None())?,
     }
-    match md.bytes_near {
-        Some(window) => {
-            kwargs.set_item("bytes_near", PyBytes::new(py, &window.bytes))?;
-            kwargs.set_item("bytes_near_offset", window.start_offset)?;
-        },
-        None => {
-            kwargs.set_item("bytes_near", py.None())?;
-            kwargs.set_item("bytes_near_offset", py.None())?;
-        },
+    if let Some(window) = md.bytes_near {
+        kwargs.set_item("bytes_near", PyBytes::new(py, &window.bytes))?;
+        kwargs.set_item("bytes_near_offset", window.start_offset)?;
+    } else {
+        kwargs.set_item("bytes_near", py.None())?;
+        kwargs.set_item("bytes_near_offset", py.None())?;
     }
 
     let class_name: &'static str = match err {

--- a/src-python/src/formats.rs
+++ b/src-python/src/formats.rs
@@ -39,7 +39,7 @@ use serde_json::Value;
 /// Convert a MARC record to JSON.
 ///
 /// # Arguments
-/// * `record` - A PyRecord instance
+/// * `record` - A `PyRecord` instance
 ///
 /// # Returns
 /// A JSON string representation of the record
@@ -64,7 +64,7 @@ pub fn record_to_json(record: &pyo3::Bound<'_, pyo3::PyAny>) -> PyResult<String>
 /// * `json_str` - A JSON string representing a MARC record
 ///
 /// # Returns
-/// A PyRecord instance
+/// A `PyRecord` instance
 ///
 /// # Example
 /// ```python
@@ -85,7 +85,7 @@ pub fn json_to_record(json_str: &str) -> PyResult<PyRecord> {
 /// Convert a MARC record to MARCXML.
 ///
 /// # Arguments
-/// * `record` - A PyRecord instance
+/// * `record` - A `PyRecord` instance
 ///
 /// # Returns
 /// A MARCXML string representation of the record
@@ -108,7 +108,7 @@ pub fn record_to_xml(record: &pyo3::Bound<'_, pyo3::PyAny>) -> PyResult<String> 
 /// * `xml_str` - A MARCXML string representing a MARC record
 ///
 /// # Returns
-/// A PyRecord instance
+/// A `PyRecord` instance
 ///
 /// # Example
 /// ```python
@@ -129,7 +129,7 @@ pub fn xml_to_record(xml_str: &str) -> PyResult<PyRecord> {
 /// * `xml_str` - A MARCXML string containing a `<collection>` element
 ///
 /// # Returns
-/// A list of PyRecord instances
+/// A list of `PyRecord` instances
 ///
 /// # Example
 /// ```python
@@ -146,7 +146,7 @@ pub fn xml_to_records(xml_str: &str) -> PyResult<Vec<PyRecord>> {
 /// Convert a MARC record to MARCJSON (JSON-LD format).
 ///
 /// # Arguments
-/// * `record` - A PyRecord instance
+/// * `record` - A `PyRecord` instance
 ///
 /// # Returns
 /// A JSON string in MARCJSON format
@@ -171,7 +171,7 @@ pub fn record_to_marcjson(record: &pyo3::Bound<'_, pyo3::PyAny>) -> PyResult<Str
 /// * `marcjson_str` - A JSON string in MARCJSON format
 ///
 /// # Returns
-/// A PyRecord instance
+/// A `PyRecord` instance
 ///
 /// # Example
 /// ```python
@@ -194,7 +194,7 @@ pub fn marcjson_to_record(marcjson_str: &str) -> PyResult<PyRecord> {
 /// Returns a dictionary with Dublin Core elements extracted from the record.
 ///
 /// # Arguments
-/// * `record` - A PyRecord instance
+/// * `record` - A `PyRecord` instance
 ///
 /// # Returns
 /// A dictionary mapping Dublin Core field names to values
@@ -240,7 +240,7 @@ pub fn record_to_dublin_core(
 /// XML representation than Dublin Core.
 ///
 /// # Arguments
-/// * `record` - A PyRecord instance
+/// * `record` - A `PyRecord` instance
 ///
 /// # Returns
 /// An XML string in MODS format
@@ -263,7 +263,7 @@ pub fn record_to_mods(record: &pyo3::Bound<'_, pyo3::PyAny>) -> PyResult<String>
 /// * `xml_str` - A MODS XML string
 ///
 /// # Returns
-/// A PyRecord instance
+/// A `PyRecord` instance
 ///
 /// # Example
 /// ```python
@@ -283,7 +283,7 @@ pub fn mods_to_record(xml_str: &str) -> PyResult<PyRecord> {
 /// * `xml_str` - A MODS collection XML string containing `<modsCollection>`
 ///
 /// # Returns
-/// A list of PyRecord instances
+/// A list of `PyRecord` instances
 ///
 /// # Example
 /// ```python
@@ -299,11 +299,11 @@ pub fn mods_collection_to_records(xml_str: &str) -> PyResult<Vec<PyRecord>> {
 
 /// Convert a MARC record directly to Dublin Core XML format.
 ///
-/// Convenience function that combines record_to_dublin_core() and dublin_core_to_xml()
+/// Convenience function that combines `record_to_dublin_core()` and `dublin_core_to_xml()`
 /// in a single call.
 ///
 /// # Arguments
-/// * `record` - A PyRecord instance
+/// * `record` - A `PyRecord` instance
 ///
 /// # Returns
 /// An XML string in Dublin Core RDF/XML format
@@ -374,7 +374,7 @@ pub fn dublin_core_to_xml(
 /// - `value`: The field or subfield value
 ///
 /// # Arguments
-/// * `record` - A PyRecord instance (can be the internal _mrrc.Record or wrapped Record)
+/// * `record` - A `PyRecord` instance (can be the internal _mrrc.Record or wrapped Record)
 ///
 /// # Returns
 /// A CSV string representation of the record
@@ -401,7 +401,7 @@ pub fn record_to_csv(record: &pyo3::Bound<'_, pyo3::PyAny>) -> PyResult<String> 
 /// - `value`: The field or subfield value
 ///
 /// # Arguments
-/// * `records` - A list of PyRecord instances
+/// * `records` - A list of `PyRecord` instances
 ///
 /// # Returns
 /// A CSV string representation of all records
@@ -443,7 +443,7 @@ pub fn records_to_csv(records: &pyo3::Bound<'_, pyo3::types::PyList>) -> PyResul
 /// provided filter function will be included.
 ///
 /// # Arguments
-/// * `records` - A list of PyRecord instances
+/// * `records` - A list of `PyRecord` instances
 /// * `filter_fn` - A callable that takes a field tag (str) and returns True to include it
 ///
 /// # Returns

--- a/src-python/src/holdings_readers.rs
+++ b/src-python/src/holdings_readers.rs
@@ -20,14 +20,16 @@ enum HoldingsReaderBackend {
     PythonFile(Py<PyAny>),
 }
 
-/// Python wrapper for HoldingsMarcReader
+/// Python wrapper for `HoldingsMarcReader`
 ///
 /// Reads MARC Holdings records from different sources with automatic
 /// backend selection:
-/// - File paths → RustFile (parallel-safe)
-/// - Bytes/BytesIO → CursorBackend (parallel-safe)
-/// - Python file objects → PythonFile (requires GIL)
+/// - File paths → `RustFile` (parallel-safe)
+/// - Bytes/BytesIO → `CursorBackend` (parallel-safe)
+/// - Python file objects → `PythonFile` (requires GIL)
 #[pyclass(name = "HoldingsMARCReader")]
+// wraps HoldingsReaderBackend which does not implement Debug
+#[allow(missing_debug_implementations)]
 pub struct PyHoldingsMARCReader {
     backend: Option<HoldingsReaderBackend>,
     recovery_mode: RecoveryMode,
@@ -36,7 +38,7 @@ pub struct PyHoldingsMARCReader {
 
 #[pymethods]
 impl PyHoldingsMARCReader {
-    /// Create a new HoldingsMARCReader
+    /// Create a new `HoldingsMARCReader`
     ///
     /// # Arguments
     /// * `source` - File path (str), pathlib.Path, bytes, or file-like object
@@ -45,7 +47,7 @@ impl PyHoldingsMARCReader {
     ///   permissive for pymarc-shape parity; the Rust core defaults
     ///   to strict for explicit-error-handling parity with Rust idiom.
     /// * `validation_level` - What counts as an error during parsing:
-    ///   'structural' (default) or 'strict_marc'.
+    ///   'structural' (default) or '`strict_marc`'.
     #[new]
     #[pyo3(signature = (source, *, recovery_mode = "permissive", validation_level = "structural"))]
     pub fn new(

--- a/src-python/src/lib.rs
+++ b/src-python/src/lib.rs
@@ -1,5 +1,20 @@
-// MRRC Python wrapper using PyO3
-// This module provides Python bindings to the Rust MARC library
+//! Python bindings for the `mrrc` MARC library, exposed as the `_mrrc`
+//! extension module via `PyO3`.
+
+// PyO3 extension code legitimately uses `unsafe` to cross the GIL boundary and
+// hand buffers to Python; allow it crate-wide here (the shared workspace lints
+// deny `unsafe_code` by default for the safe-Rust core).
+#![allow(unsafe_code)]
+// `unnecessary_wraps` and `needless_pass_by_value` are allowed crate-wide
+// because they fire pervasively on the binding surface for sound reasons:
+// Python protocol methods (`__iter__`, `__exit__`, `close`, the `to_json`
+// converters) return `PyResult` for protocol conformance and forward
+// compatibility even where a given impl is currently infallible; and
+// `#[pyfunction]` arguments are extracted by value by PyO3 — for the parallel
+// parsers the owned `Vec<u8>` buffer is load-bearing, since a borrow into
+// Python memory could be freed or mutated across the GIL release.
+#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::needless_pass_by_value)]
 
 mod authority_readers;
 mod backend;

--- a/src-python/src/producer_consumer_pipeline_wrapper.rs
+++ b/src-python/src/producer_consumer_pipeline_wrapper.rs
@@ -1,4 +1,4 @@
-//! PyO3 bindings for the Producer-Consumer Pipeline
+//! `PyO3` bindings for the Producer-Consumer Pipeline
 //!
 //! Exposes [`ProducerConsumerPipeline`] as a Python class, enabling high-performance
 //! batch reading with backpressure management from Python code.
@@ -35,6 +35,7 @@ use pyo3::prelude::*;
 /// print(f"Processed {record_count} records")
 /// ```
 #[pyclass(name = "ProducerConsumerPipeline")]
+#[derive(Debug)]
 pub struct PyProducerConsumerPipeline {
     inner: Option<ProducerConsumerPipeline>,
 }

--- a/src-python/src/query.rs
+++ b/src-python/src/query.rs
@@ -7,7 +7,7 @@
 use mrrc::field_query::{FieldQuery, SubfieldPatternQuery, SubfieldValueQuery, TagRangeQuery};
 use pyo3::prelude::*;
 
-/// Python wrapper for FieldQuery - a builder for complex field matching.
+/// Python wrapper for `FieldQuery` - a builder for complex field matching.
 ///
 /// `FieldQuery` uses the builder pattern to construct queries that can match
 /// on tags, indicators, and subfield presence. This provides functionality
@@ -27,7 +27,7 @@ use pyo3::prelude::*;
 /// query = mrrc.FieldQuery().indicator1("1").indicator2("0")
 /// ```
 #[pyclass(name = "FieldQuery", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PyFieldQuery {
     pub inner: FieldQuery,
 }
@@ -37,10 +37,10 @@ impl PyFieldQuery {
     /// Create a new query that matches all fields.
     ///
     /// Returns:
-    ///     FieldQuery: A new query builder with no restrictions.
+    ///     `FieldQuery`: A new query builder with no restrictions.
     ///
     /// Example:
-    ///     >>> query = mrrc.FieldQuery()  # matches all fields
+    ///     >>> query = `mrrc.FieldQuery()`  # matches all fields
     #[new]
     pub fn new() -> Self {
         PyFieldQuery {
@@ -54,7 +54,7 @@ impl PyFieldQuery {
     ///     tag: The 3-character field tag (e.g., "650", "245").
     ///
     /// Returns:
-    ///     FieldQuery: Self, for method chaining.
+    ///     `FieldQuery`: Self, for method chaining.
     ///
     /// Example:
     ///     >>> query = mrrc.FieldQuery().tag("650")
@@ -70,7 +70,7 @@ impl PyFieldQuery {
     ///     indicator: Single character indicator value, or None to match any.
     ///
     /// Returns:
-    ///     FieldQuery: Self, for method chaining.
+    ///     `FieldQuery`: Self, for method chaining.
     ///
     /// Example:
     ///     >>> query = mrrc.FieldQuery().indicator1("1")  # match ind1='1'
@@ -89,7 +89,7 @@ impl PyFieldQuery {
     ///     indicator: Single character indicator value, or None to match any.
     ///
     /// Returns:
-    ///     FieldQuery: Self, for method chaining.
+    ///     `FieldQuery`: Self, for method chaining.
     ///
     /// Example:
     ///     >>> query = mrrc.FieldQuery().indicator2("0")  # match ind2='0' (LCSH)
@@ -110,11 +110,11 @@ impl PyFieldQuery {
     ///     code: Single character subfield code (e.g., "a", "x").
     ///
     /// Returns:
-    ///     FieldQuery: Self, for method chaining.
+    ///     `FieldQuery`: Self, for method chaining.
     ///
     /// Example:
-    ///     >>> query = mrrc.FieldQuery().tag("650").has_subfield("a")
-    ///     >>> query = query.has_subfield("x")  # must have both 'a' AND 'x'
+    ///     >>> query = `mrrc.FieldQuery().tag("650").has_subfield("a`")
+    ///     >>> query = `query.has_subfield("x`")  # must have both 'a' AND 'x'
     pub fn has_subfield(&self, code: &str) -> PyResult<Self> {
         if code.is_empty() {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -133,10 +133,10 @@ impl PyFieldQuery {
     ///     codes: List of single-character subfield codes.
     ///
     /// Returns:
-    ///     FieldQuery: Self, for method chaining.
+    ///     `FieldQuery`: Self, for method chaining.
     ///
     /// Example:
-    ///     >>> query = mrrc.FieldQuery().tag("650").has_subfields(["a", "x", "v"])
+    ///     >>> query = `mrrc.FieldQuery().tag("650").has_subfields(["a", "x", "v"])`
     pub fn has_subfields(&self, codes: Vec<String>) -> PyResult<Self> {
         let chars: Vec<char> = codes.into_iter().filter_map(|s| s.chars().next()).collect();
         if chars.is_empty() {
@@ -155,14 +155,14 @@ impl PyFieldQuery {
     /// any indicator and subfield requirements already set.
     ///
     /// Args:
-    ///     start_tag: Start of tag range (inclusive), e.g., "600".
-    ///     end_tag: End of tag range (inclusive), e.g., "699".
+    ///     `start_tag`: Start of tag range (inclusive), e.g., "600".
+    ///     `end_tag`: End of tag range (inclusive), e.g., "699".
     ///
     /// Returns:
-    ///     TagRangeQuery: A new range-based query.
+    ///     `TagRangeQuery`: A new range-based query.
     ///
     /// Example:
-    ///     >>> query = mrrc.FieldQuery().indicator2("0").tag_range("600", "699")
+    ///     >>> query = `mrrc.FieldQuery().indicator2("0").tag_range("600`", "699")
     ///     >>> # Matches all 6XX fields with ind2='0'
     pub fn tag_range(&self, start_tag: &str, end_tag: &str) -> PyTagRangeQuery {
         PyTagRangeQuery {
@@ -175,7 +175,7 @@ impl PyFieldQuery {
             .inner
             .tag
             .as_ref()
-            .map_or("*".to_string(), |t| t.clone());
+            .map_or("*".to_string(), std::clone::Clone::clone);
         let ind1 = self
             .inner
             .indicator1
@@ -195,7 +195,7 @@ impl PyFieldQuery {
     }
 }
 
-/// Python wrapper for TagRangeQuery - query fields within a tag range.
+/// Python wrapper for `TagRangeQuery` - query fields within a tag range.
 ///
 /// This query type matches fields whose tags fall within a specified range,
 /// useful for querying groups of related fields (e.g., all 6XX subject fields).
@@ -211,7 +211,7 @@ impl PyFieldQuery {
 ///     print(f"Subject: {field}")
 /// ```
 #[pyclass(name = "TagRangeQuery", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PyTagRangeQuery {
     pub inner: TagRangeQuery,
 }
@@ -221,11 +221,11 @@ impl PyTagRangeQuery {
     /// Create a new tag range query.
     ///
     /// Args:
-    ///     start_tag: Start of tag range (inclusive), e.g., "600".
-    ///     end_tag: End of tag range (inclusive), e.g., "699".
+    ///     `start_tag`: Start of tag range (inclusive), e.g., "600".
+    ///     `end_tag`: End of tag range (inclusive), e.g., "699".
     ///     indicator1: Optional first indicator filter (None = match any).
     ///     indicator2: Optional second indicator filter (None = match any).
-    ///     required_subfields: Optional list of required subfield codes.
+    ///     `required_subfields`: Optional list of required subfield codes.
     ///
     /// Example:
     ///     >>> query = mrrc.TagRangeQuery("600", "699", indicator2="0")
@@ -313,7 +313,7 @@ impl PyTagRangeQuery {
     }
 }
 
-/// Python wrapper for SubfieldPatternQuery - regex matching on subfield values.
+/// Python wrapper for `SubfieldPatternQuery` - regex matching on subfield values.
 ///
 /// This query type finds fields where a specific subfield's value matches
 /// a regular expression pattern.
@@ -333,7 +333,7 @@ impl PyTagRangeQuery {
 /// query = mrrc.SubfieldPatternQuery("100", "d", r"\d{4}-\d{4}")
 /// ```
 #[pyclass(name = "SubfieldPatternQuery", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PySubfieldPatternQuery {
     pub inner: SubfieldPatternQuery,
 }
@@ -344,11 +344,11 @@ impl PySubfieldPatternQuery {
     ///
     /// Args:
     ///     tag: The 3-character field tag to search in.
-    ///     subfield_code: The subfield code to match against.
+    ///     `subfield_code`: The subfield code to match against.
     ///     pattern: A regex pattern string.
     ///
     /// Raises:
-    ///     ValueError: If the pattern is not a valid regular expression.
+    ///     `ValueError`: If the pattern is not a valid regular expression.
     ///
     /// Example:
     ///     >>> query = mrrc.SubfieldPatternQuery("020", "a", r"^978-")
@@ -373,8 +373,7 @@ impl PySubfieldPatternQuery {
         match inner {
             Ok(query) => Ok(PySubfieldPatternQuery { inner: query }),
             Err(e) => Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "Invalid regex pattern: {}",
-                e
+                "Invalid regex pattern: {e}"
             ))),
         }
     }
@@ -428,7 +427,7 @@ impl PySubfieldPatternQuery {
     }
 }
 
-/// Python wrapper for SubfieldValueQuery - exact or partial string matching.
+/// Python wrapper for `SubfieldValueQuery` - exact or partial string matching.
 ///
 /// This query type finds fields where a specific subfield's value matches
 /// a string, either exactly or as a substring.
@@ -445,7 +444,7 @@ impl PySubfieldPatternQuery {
 /// query = mrrc.SubfieldValueQuery("650", "a", "History", partial=True)
 /// ```
 #[pyclass(name = "SubfieldValueQuery", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PySubfieldValueQuery {
     pub inner: SubfieldValueQuery,
 }
@@ -456,7 +455,7 @@ impl PySubfieldValueQuery {
     ///
     /// Args:
     ///     tag: The 3-character field tag to search in.
-    ///     subfield_code: The subfield code to match against.
+    ///     `subfield_code`: The subfield code to match against.
     ///     value: The value to match.
     ///     partial: If True, match substrings. If False (default), exact match.
     ///

--- a/src-python/src/rayon_parser_pool_wrapper.rs
+++ b/src-python/src/rayon_parser_pool_wrapper.rs
@@ -1,4 +1,4 @@
-//! PyO3 bindings for the Rayon parser pool.
+//! `PyO3` bindings for the Rayon parser pool.
 //!
 //! Exposes [`parse_batch_parallel`] as a Python function, allowing
 //! parallel MARC record parsing from Python code.
@@ -16,7 +16,7 @@ use pyo3::prelude::*;
 ///
 /// # Returns
 ///
-/// A list of PyRecord instances, one for each boundary.
+/// A list of `PyRecord` instances, one for each boundary.
 ///
 /// # Raises
 ///
@@ -57,7 +57,7 @@ pub fn parse_batch_parallel(
     let records = py
         .detach(|| rayon_parser_pool::parse_batch_parallel(&boundaries, &buffer).map_err(Box::new))
         .map_err(|e| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Parse error: {}", e))
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Parse error: {e}"))
         })?;
 
     // Convert Rust records to PyRecord wrappers (GIL re-acquired after detach)
@@ -76,7 +76,7 @@ pub fn parse_batch_parallel(
 ///
 /// # Returns
 ///
-/// A list of up to `limit` PyRecord instances.
+/// A list of up to `limit` `PyRecord` instances.
 ///
 /// # Example
 ///
@@ -108,7 +108,7 @@ pub fn parse_batch_parallel_limited(
                 .map_err(Box::new)
         })
         .map_err(|e| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Parse error: {}", e))
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Parse error: {e}"))
         })?;
 
     // Convert to PyRecord (GIL re-acquired after detach)

--- a/src-python/src/reader_helpers.rs
+++ b/src-python/src/reader_helpers.rs
@@ -1,6 +1,6 @@
 //! Shared helpers for MARC reader backends (authority, holdings).
 //!
-//! Eliminates duplication between authority_readers.rs and holdings_readers.rs
+//! Eliminates duplication between `authority_readers.rs` and `holdings_readers.rs`
 //! for common operations: recovery mode parsing, source file opening, and
 //! reading raw record bytes from Python file objects.
 
@@ -8,7 +8,7 @@ use mrrc::recovery::{RecoveryMode, ValidationLevel};
 use pyo3::prelude::*;
 use std::fs::File;
 
-/// Parse a recovery_mode string into a RecoveryMode enum.
+/// Parse a `recovery_mode` string into a `RecoveryMode` enum.
 ///
 /// Returns `PyValueError` for invalid values.
 pub fn parse_recovery_mode(mode: &str) -> PyResult<RecoveryMode> {
@@ -17,13 +17,12 @@ pub fn parse_recovery_mode(mode: &str) -> PyResult<RecoveryMode> {
         "permissive" => Ok(RecoveryMode::Permissive),
         "strict" => Ok(RecoveryMode::Strict),
         _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
-            "Invalid recovery_mode '{}': must be 'strict', 'lenient', or 'permissive'",
-            mode
+            "Invalid recovery_mode '{mode}': must be 'strict', 'lenient', or 'permissive'"
         ))),
     }
 }
 
-/// Parse a validation_level string into a ValidationLevel enum.
+/// Parse a `validation_level` string into a `ValidationLevel` enum.
 ///
 /// Returns `PyValueError` for invalid values.
 pub fn parse_validation_level(level: &str) -> PyResult<ValidationLevel> {
@@ -31,8 +30,7 @@ pub fn parse_validation_level(level: &str) -> PyResult<ValidationLevel> {
         "structural" => Ok(ValidationLevel::Structural),
         "strict_marc" => Ok(ValidationLevel::StrictMarc),
         _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
-            "Invalid validation_level '{}': must be 'structural' or 'strict_marc'",
-            level
+            "Invalid validation_level '{level}': must be 'structural' or 'strict_marc'"
         ))),
     }
 }
@@ -65,16 +63,14 @@ fn open_file_path(path: &str) -> PyResult<File> {
         Ok(file) => Ok(file),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
-                "No such file or directory: '{}'",
-                path
+                "No such file or directory: '{path}'"
             )))
         },
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => Err(
-            pyo3::exceptions::PyPermissionError::new_err(format!("Permission denied: '{}'", path)),
+            pyo3::exceptions::PyPermissionError::new_err(format!("Permission denied: '{path}'")),
         ),
         Err(e) => Err(pyo3::exceptions::PyIOError::new_err(format!(
-            "Failed to open file '{}': {}",
-            path, e
+            "Failed to open file '{path}': {e}"
         ))),
     }
 }
@@ -89,9 +85,9 @@ pub fn try_extract_bytes(source: &Bound<'_, PyAny>) -> PyResult<Option<Vec<u8>>>
     }
 }
 
-/// Try to get a Python file-like object (has .read() method).
+/// Try to get a Python file-like object (has .`read()` method).
 ///
-/// Returns `Ok(Some(obj))` if the source has a callable .read(), `Ok(None)` otherwise.
+/// Returns `Ok(Some(obj))` if the source has a callable .`read()`, `Ok(None)` otherwise.
 pub fn try_as_python_file(source: &Bound<'_, PyAny>) -> PyResult<Option<Py<PyAny>>> {
     if let Ok(method) = source.getattr("read")
         && method.is_callable()
@@ -105,9 +101,8 @@ pub fn try_as_python_file(source: &Bound<'_, PyAny>) -> PyResult<Option<Py<PyAny
 pub fn unsupported_source_error(source: &Bound<'_, PyAny>) -> PyResult<()> {
     let type_name = source.get_type().name()?;
     Err(pyo3::exceptions::PyTypeError::new_err(format!(
-        "Unsupported input type: {}. Supported types: str (file path), pathlib.Path, \
-         bytes, bytearray, or file-like object (with .read() method)",
-        type_name
+        "Unsupported input type: {type_name}. Supported types: str (file path), pathlib.Path, \
+         bytes, bytearray, or file-like object (with .read() method)"
     )))
 }
 
@@ -117,13 +112,13 @@ pub fn unsupported_source_error(source: &Bound<'_, PyAny>) -> PyResult<()> {
 /// or `Err` for malformed/truncated data.
 pub fn read_record_bytes_from_python_file(py_obj: &Bound<'_, PyAny>) -> PyResult<Option<Vec<u8>>> {
     let read_method = py_obj.getattr("read").map_err(|e| {
-        pyo3::exceptions::PyIOError::new_err(format!("Object missing .read() method: {}", e))
+        pyo3::exceptions::PyIOError::new_err(format!("Object missing .read() method: {e}"))
     })?;
 
     // Read leader (24 bytes)
-    let leader_result = read_method.call1((24usize,)).map_err(|e| {
-        pyo3::exceptions::PyIOError::new_err(format!("Failed to read leader: {}", e))
-    })?;
+    let leader_result = read_method
+        .call1((24usize,))
+        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("Failed to read leader: {e}")))?;
 
     let leader: Vec<u8> = leader_result
         .extract()
@@ -144,21 +139,19 @@ pub fn read_record_bytes_from_python_file(py_obj: &Bound<'_, PyAny>) -> PyResult
     let record_length_str = String::from_utf8_lossy(&leader[0..5]);
     let record_length: usize = record_length_str.trim().parse().map_err(|_| {
         pyo3::exceptions::PyValueError::new_err(format!(
-            "Invalid record length in leader: '{}'",
-            record_length_str
+            "Invalid record length in leader: '{record_length_str}'"
         ))
     })?;
 
     if record_length < 24 {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
-            "Record length too small: {} (minimum 24)",
-            record_length
+            "Record length too small: {record_length} (minimum 24)"
         )));
     }
 
     // Read remainder
     let record_data_bytes = read_method.call1((record_length - 24,)).map_err(|e| {
-        pyo3::exceptions::PyIOError::new_err(format!("Failed to read record data: {}", e))
+        pyo3::exceptions::PyIOError::new_err(format!("Failed to read record data: {e}"))
     })?;
 
     let record_data: Vec<u8> = record_data_bytes

--- a/src-python/src/readers.rs
+++ b/src-python/src/readers.rs
@@ -10,16 +10,16 @@ use crate::batched_reader::{BatchedReader, RecordOutcome};
 use crate::wrappers::PyRecord;
 use pyo3::prelude::*;
 
-/// Python wrapper for MarcReader with efficient GIL management
+/// Python wrapper for `MarcReader` with efficient GIL management
 ///
 /// Implements batch-based GIL optimization for CPU-intensive parsing:
 /// - Read bytes from source efficiently (GIL held only if Python file)
 /// - Parse bytes to MARC records (GIL released, allowing parallelism)
-/// - Convert to PyRecord (GIL re-acquired)
+/// - Convert to `PyRecord` (GIL re-acquired)
 ///
 /// ## Thread Safety
 ///
-/// **IMPORTANT**: MARCReader is NOT thread-safe. Each thread must create its own reader instance.
+/// **IMPORTANT**: `MARCReader` is NOT thread-safe. Each thread must create its own reader instance.
 /// Sharing a single reader across threads causes undefined behavior.
 ///
 /// Correct pattern:
@@ -46,6 +46,7 @@ use pyo3::prelude::*;
 /// - Multiple input types: file paths and bytes parse without touching the
 ///   GIL; Python file objects read in chunks under a single GIL hold per batch.
 #[pyclass(name = "MARCReader")]
+#[derive(Debug)]
 pub struct PyMARCReader {
     /// Batched reader over the unified record-byte backend. `None` once the
     /// stream is exhausted or a fatal cap error has consumed the reader.
@@ -88,12 +89,12 @@ pub struct PyMARCReader {
 
 #[pymethods]
 impl PyMARCReader {
-    /// Create a new MARCReader from any supported source
+    /// Create a new `MARCReader` from any supported source
     ///
     /// Accepts:
-    /// - str path (e.g., 'records.mrc') → RustFile backend (no GIL)
-    /// - pathlib.Path → RustFile backend (no GIL)
-    /// - bytes/bytearray → CursorBackend (no GIL)
+    /// - str path (e.g., 'records.mrc') → `RustFile` backend (no GIL)
+    /// - pathlib.Path → `RustFile` backend (no GIL)
+    /// - bytes/bytearray → `CursorBackend` (no GIL)
     /// - Python file object → chunked Python-file backend (GIL managed)
     ///
     /// # Arguments
@@ -103,7 +104,7 @@ impl PyMARCReader {
     ///   permissive for pymarc-shape parity; the Rust core defaults
     ///   to strict for explicit-error-handling parity with Rust idiom.
     /// * `validation_level` - What counts as an error during parsing:
-    ///   'structural' (default) or 'strict_marc'. Orthogonal to
+    ///   'structural' (default) or '`strict_marc`'. Orthogonal to
     ///   `recovery_mode`.
     /// * `max_errors` - Optional cap on accumulated recovered errors
     ///   per stream in lenient/permissive mode. `None` (default)
@@ -191,17 +192,17 @@ impl PyMARCReader {
     ///
     /// This implements efficient GIL release pattern:
     /// - Step 1: Read record bytes from source (GIL held if Python file)
-    ///   - Uses queue-based state machine (CHECK_QUEUE → CHECK_EOF → READ_BATCH)
+    ///   - Uses queue-based state machine (`CHECK_QUEUE` → `CHECK_EOF` → `READ_BATCH`)
     /// - Step 2: Parse bytes to MARC record (GIL released)
     ///   - This step releases the GIL, allowing other threads to execute
-    /// - Step 3: Convert to PyRecord (GIL re-acquired)
+    /// - Step 3: Convert to `PyRecord` (GIL re-acquired)
     ///
     /// **Concurrency Benefits:**
     /// Using separate readers in multiple threads achieves:
     /// - 2 threads: ~2.0x speedup vs sequential
     /// - 4 threads: ~3.2x speedup vs sequential
     /// - GIL is released during parsing for each record
-    /// - See ThreadPoolExecutor example in MARCReader struct docs
+    /// - See `ThreadPoolExecutor` example in `MARCReader` struct docs
     ///
     /// **Optimization Strategies:**
     /// - Batch parsing: a whole batch (up to 200 records / 300 KB) is parsed
@@ -227,13 +228,10 @@ impl PyMARCReader {
             reader.next_record(py)
         };
 
-        let outcome = match outcome {
-            Some(outcome) => outcome,
-            None => {
-                // Clean end of stream — mark the reader consumed.
-                slf.reader = None;
-                return Err(pyo3::exceptions::PyStopIteration::new_err(()));
-            },
+        let Some(outcome) = outcome else {
+            // Clean end of stream — mark the reader consumed.
+            slf.reader = None;
+            return Err(pyo3::exceptions::PyStopIteration::new_err(()));
         };
 
         match slf.apply_outcome(outcome)? {
@@ -244,7 +242,7 @@ impl PyMARCReader {
         }
     }
 
-    /// Return the backend type: "rust_file", "cursor", or "python_file"
+    /// Return the backend type: "`rust_file`", "cursor", or "`python_file`"
     #[getter]
     fn backend_type(&self) -> PyResult<String> {
         match &self.reader {
@@ -307,7 +305,7 @@ impl PyMARCReader {
     /// Returns `Ok(())` when the cap is disabled (`max_errors=None`
     /// or `Some(0)`) or still under the configured limit.
     ///
-    /// Lives in a non-`#[pymethods]` impl block so PyO3 does not try
+    /// Lives in a non-`#[pymethods]` impl block so `PyO3` does not try
     /// to expose it as a Python method (the `&mrrc::Record` argument
     /// is not a Python-extractable type).
     fn note_record_errors(&mut self, record: &mrrc::Record) -> Result<(), Box<mrrc::MarcError>> {

--- a/src-python/src/wrappers.rs
+++ b/src-python/src/wrappers.rs
@@ -17,7 +17,7 @@ use pyo3::prelude::*;
 /// leader.bibliographic_level = 'm'  # Monograph
 /// ```
 #[pyclass(name = "Leader", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PyLeader {
     pub inner: Leader,
 }
@@ -282,7 +282,7 @@ impl PyLeader {
     /// ```
     #[staticmethod]
     pub fn describe_value(position: usize, value: &str) -> Option<String> {
-        Leader::describe_value(position, value).map(|s| s.to_string())
+        Leader::describe_value(position, value).map(std::string::ToString::to_string)
     }
 
     /// Check if a value is valid for a specific leader position.
@@ -310,7 +310,7 @@ impl PyLeader {
         Leader::is_valid_value(position, value)
     }
 
-    /// Get description for a specific value at a leader position (alias for describe_value).
+    /// Get description for a specific value at a leader position (alias for `describe_value`).
     ///
     /// # Arguments
     ///
@@ -322,7 +322,7 @@ impl PyLeader {
     /// The description if found, or None if the value is invalid for the position
     #[staticmethod]
     pub fn get_value_description(position: usize, value: &str) -> Option<String> {
-        Leader::describe_value(position, value).map(|s| s.to_string())
+        Leader::describe_value(position, value).map(std::string::ToString::to_string)
     }
 }
 
@@ -346,7 +346,7 @@ impl Default for PyLeader {
 /// print(f"Code: {sf.code}, Value: {sf.value}")
 /// ```
 #[pyclass(name = "Subfield", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PySubfield {
     pub inner: Subfield,
 }
@@ -417,7 +417,7 @@ impl PySubfield {
 /// field.add_subfield('c', 'F. Scott Fitzgerald')
 /// ```
 #[pyclass(name = "Field", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PyField {
     pub inner: Field,
 }
@@ -638,6 +638,7 @@ impl PyField {
 /// print(f"Title: {record.title()}")
 /// ```
 #[pyclass(name = "Record")]
+#[derive(Debug)]
 pub struct PyRecord {
     pub inner: Record,
     /// Bumped by every field removal. Python-side field handles capture
@@ -702,7 +703,9 @@ impl PyRecord {
 
     /// Get a control field value
     pub fn control_field(&self, tag: &str) -> Option<String> {
-        self.inner.get_control_field(tag).map(|s| s.to_string())
+        self.inner
+            .get_control_field(tag)
+            .map(std::string::ToString::to_string)
     }
 
     /// Add a data field
@@ -912,17 +915,17 @@ impl PyRecord {
 
     /// Get title from 245 field (first subfield $a)
     pub fn title(&self) -> Option<String> {
-        self.inner.title().map(|s| s.to_string())
+        self.inner.title().map(std::string::ToString::to_string)
     }
 
     /// Get author from 100/110/111 field
     pub fn author(&self) -> Option<String> {
-        self.inner.author().map(|s| s.to_string())
+        self.inner.author().map(std::string::ToString::to_string)
     }
 
     /// Get ISBN from 020 field
     pub fn isbn(&self) -> Option<String> {
-        self.inner.isbn().map(|s| s.to_string())
+        self.inner.isbn().map(std::string::ToString::to_string)
     }
 
     /// Get all subject headings from 6XX subject fields
@@ -930,7 +933,7 @@ impl PyRecord {
         self.inner
             .subjects()
             .iter()
-            .map(|s| s.to_string())
+            .map(std::string::ToString::to_string)
             .collect()
     }
 
@@ -939,58 +942,68 @@ impl PyRecord {
         self.inner
             .location()
             .iter()
-            .map(|s| s.to_string())
+            .map(std::string::ToString::to_string)
             .collect()
     }
 
     /// Get all notes from 5xx fields
     pub fn notes(&self) -> Vec<String> {
-        self.inner.notes().iter().map(|s| s.to_string()).collect()
+        self.inner
+            .notes()
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect()
     }
 
     /// Get publisher from 260 or 264 (RDA) field
     pub fn publisher(&self) -> Option<String> {
-        self.inner.publisher().map(|s| s.to_string())
+        self.inner.publisher().map(std::string::ToString::to_string)
     }
 
     /// Get uniform title from 130 field
     pub fn uniform_title(&self) -> Option<String> {
-        self.inner.uniform_title().map(|s| s.to_string())
+        self.inner
+            .uniform_title()
+            .map(std::string::ToString::to_string)
     }
 
-    /// Get SuDoc (government document classification) from 086 field
+    /// Get `SuDoc` (government document classification) from 086 field
     pub fn sudoc(&self) -> Option<String> {
-        self.inner.sudoc().map(|s| s.to_string())
+        self.inner.sudoc().map(std::string::ToString::to_string)
     }
 
     /// Get ISSN title from 222 field
     pub fn issn_title(&self) -> Option<String> {
-        self.inner.issn_title().map(|s| s.to_string())
+        self.inner
+            .issn_title()
+            .map(std::string::ToString::to_string)
     }
 
     /// Get ISSN-L from 024 field
     pub fn issnl(&self) -> Option<String> {
-        self.inner.issnl().map(|s| s.to_string())
+        self.inner.issnl().map(std::string::ToString::to_string)
     }
 
-    /// Get publication year (alias for publication_year)
+    /// Get publication year (alias for `publication_year`)
     pub fn pubyear(&self) -> Option<u32> {
         self.inner.pubyear()
     }
 
     /// Get ISSN from 022 field
     pub fn issn(&self) -> Option<String> {
-        self.inner.issn().map(|s| s.to_string())
+        self.inner.issn().map(std::string::ToString::to_string)
     }
 
     /// Get series from 490 field
     pub fn series(&self) -> Option<String> {
-        self.inner.series().map(|s| s.to_string())
+        self.inner.series().map(std::string::ToString::to_string)
     }
 
     /// Get physical description from 300 field
     pub fn physical_description(&self) -> Option<String> {
-        self.inner.physical_description().map(|s| s.to_string())
+        self.inner
+            .physical_description()
+            .map(std::string::ToString::to_string)
     }
 
     /// Check if this record is a book (record type 'a' + bibliographic level 'm')
@@ -1032,9 +1045,9 @@ impl PyRecord {
     ///
     /// Example:
     ///     >>> # Find all 650 fields with indicator2='0' (Library of Congress Subject Headings)
-    ///     >>> lcsh_subjects = record.fields_by_indicator("650", indicator2="0")
-    ///     >>> for field in lcsh_subjects:
-    ///     ...     print(field.get_subfield("a"))
+    ///     >>> `lcsh_subjects` = `record.fields_by_indicator("650`", indicator2="0")
+    ///     >>> for field in `lcsh_subjects`:
+    ///     ...     `print(field.get_subfield("a`"))
     #[pyo3(signature = (tag, *, indicator1=None, indicator2=None))]
     pub fn fields_by_indicator(
         &self,
@@ -1056,17 +1069,17 @@ impl PyRecord {
     /// (600-699) or all added entry fields (700-799).
     ///
     /// Args:
-    ///     start_tag: Start of range (inclusive), e.g., "600".
-    ///     end_tag: End of range (inclusive), e.g., "699".
+    ///     `start_tag`: Start of range (inclusive), e.g., "600".
+    ///     `end_tag`: End of range (inclusive), e.g., "699".
     ///
     /// Returns:
     ///     List of Field objects within the tag range.
     ///
     /// Example:
     ///     >>> # Find all subject fields (600-699)
-    ///     >>> subjects = record.fields_in_range("600", "699")
+    ///     >>> subjects = `record.fields_in_range("600`", "699")
     ///     >>> for field in subjects:
-    ///     ...     print(f"{field.tag}: {field.get_subfield('a')}")
+    ///     ...     print(f"{field.tag}: {`field.get_subfield`('a')}")
     pub fn fields_in_range(&self, start_tag: &str, end_tag: &str) -> Vec<PyField> {
         self.inner
             .fields_in_range(start_tag, end_tag)
@@ -1092,8 +1105,8 @@ impl PyRecord {
     ///     List of linked 880 Field objects (empty if no linkage or no match).
     ///
     /// Example:
-    ///     >>> f245 = record.get_fields('245')\[0\]
-    ///     >>> linked = record.get_linked_fields(f245)
+    ///     >>> f245 = `record.get_fields`('245')\[0\]
+    ///     >>> linked = `record.get_linked_fields(f245)`
     ///     >>> if linked:
     ///     ...     print(linked\[0\]\['a'\])
     pub fn get_linked_fields(&self, field: &PyField) -> Vec<PyField> {
@@ -1106,7 +1119,7 @@ impl PyRecord {
 
     /// Find the single 880 field linked to a given field via subfield $6.
     ///
-    /// Like get_linked_fields() but returns only the first match. Use this
+    /// Like `get_linked_fields()` but returns only the first match. Use this
     /// when you expect exactly one linked 880 (the common case).
     ///
     /// Args:
@@ -1126,7 +1139,7 @@ impl PyRecord {
     /// tag and occurrence from its $6 subfield.
     ///
     /// Args:
-    ///     field_880: An 880 Field object.
+    ///     `field_880`: An 880 Field object.
     ///
     /// Returns:
     ///     The linked original Field, or None.
@@ -1138,7 +1151,7 @@ impl PyRecord {
 
     /// Get field pairs of original fields with their linked 880 counterparts.
     ///
-    /// For a given tag, returns tuples of (original_field, linked_880_or_None).
+    /// For a given tag, returns tuples of (`original_field`, `linked_880_or_None`).
     ///
     /// Args:
     ///     tag: The field tag to pair (e.g., '245', '100').
@@ -1147,7 +1160,7 @@ impl PyRecord {
     ///     List of (Field, Optional[Field]) tuples.
     ///
     /// Example:
-    ///     >>> for orig, linked in record.get_field_pairs('245'):
+    ///     >>> for orig, linked in `record.get_field_pairs`('245'):
     ///     ...     print(orig\['a'\])
     ///     ...     if linked:
     ///     ...         print(linked\['a'\])
@@ -1166,22 +1179,22 @@ impl PyRecord {
             .collect()
     }
 
-    /// Get fields matching a FieldQuery.
+    /// Get fields matching a `FieldQuery`.
     ///
     /// This method enables complex field matching using the Query DSL.
-    /// A FieldQuery can combine tag, indicator, and subfield requirements.
+    /// A `FieldQuery` can combine tag, indicator, and subfield requirements.
     ///
     /// Args:
-    ///     query: A FieldQuery object with the matching criteria.
+    ///     query: A `FieldQuery` object with the matching criteria.
     ///
     /// Returns:
     ///     List of Field objects matching all query criteria.
     ///
     /// Example:
-    ///     >>> query = mrrc.FieldQuery().tag("650").indicator2("0").has_subfield("a")
-    ///     >>> lcsh = record.fields_matching(query)
+    ///     >>> query = `mrrc.FieldQuery().tag("650").indicator2("0").has_subfield("a`")
+    ///     >>> lcsh = `record.fields_matching(query)`
     ///     >>> for field in lcsh:
-    ///     ...     print(field.get_subfield("a"))
+    ///     ...     `print(field.get_subfield("a`"))
     pub fn fields_matching(&self, query: &crate::query::PyFieldQuery) -> Vec<PyField> {
         self.inner
             .fields_matching(&query.inner)
@@ -1189,21 +1202,21 @@ impl PyRecord {
             .collect()
     }
 
-    /// Get fields matching a TagRangeQuery.
+    /// Get fields matching a `TagRangeQuery`.
     ///
     /// This method finds fields within a tag range that also match indicator
     /// and subfield requirements.
     ///
     /// Args:
-    ///     query: A TagRangeQuery object with range and filter criteria.
+    ///     query: A `TagRangeQuery` object with range and filter criteria.
     ///
     /// Returns:
     ///     List of Field objects matching all query criteria.
     ///
     /// Example:
     ///     >>> # Find all 6XX subjects with indicator2='0' (LCSH) that have subfield 'a'
-    ///     >>> query = mrrc.TagRangeQuery("600", "699", indicator2="0", required_subfields=["a"])
-    ///     >>> subjects = record.fields_matching_range(query)
+    ///     >>> query = `mrrc.TagRangeQuery("600", "699", indicator2="0", required_subfields=["a"])`
+    ///     >>> subjects = `record.fields_matching_range(query)`
     pub fn fields_matching_range(&self, query: &crate::query::PyTagRangeQuery) -> Vec<PyField> {
         self.inner
             .fields_matching_range(&query.inner)
@@ -1211,13 +1224,13 @@ impl PyRecord {
             .collect()
     }
 
-    /// Get fields matching a SubfieldPatternQuery (regex matching).
+    /// Get fields matching a `SubfieldPatternQuery` (regex matching).
     ///
     /// This method finds fields where a specific subfield's value matches
     /// a regular expression pattern.
     ///
     /// Args:
-    ///     query: A SubfieldPatternQuery object with tag, subfield, and regex.
+    ///     query: A `SubfieldPatternQuery` object with tag, subfield, and regex.
     ///
     /// Returns:
     ///     List of Field objects where the subfield matches the pattern.
@@ -1225,7 +1238,7 @@ impl PyRecord {
     /// Example:
     ///     >>> # Find all ISBN-13s (start with 978 or 979)
     ///     >>> query = mrrc.SubfieldPatternQuery("020", "a", r"^97\[89\]-")
-    ///     >>> isbn13_fields = record.fields_matching_pattern(query)
+    ///     >>> `isbn13_fields` = `record.fields_matching_pattern(query)`
     pub fn fields_matching_pattern(
         &self,
         query: &crate::query::PySubfieldPatternQuery,
@@ -1236,13 +1249,13 @@ impl PyRecord {
             .collect()
     }
 
-    /// Get fields matching a SubfieldValueQuery (exact or partial string matching).
+    /// Get fields matching a `SubfieldValueQuery` (exact or partial string matching).
     ///
     /// This method finds fields where a specific subfield's value matches
     /// a string exactly or as a substring.
     ///
     /// Args:
-    ///     query: A SubfieldValueQuery object with tag, subfield, value, and match type.
+    ///     query: A `SubfieldValueQuery` object with tag, subfield, value, and match type.
     ///
     /// Returns:
     ///     List of Field objects where the subfield matches the value.
@@ -1250,7 +1263,7 @@ impl PyRecord {
     /// Example:
     ///     >>> # Find exact subject heading "History"
     ///     >>> query = mrrc.SubfieldValueQuery("650", "a", "History")
-    ///     >>> history_fields = record.fields_matching_value(query)
+    ///     >>> `history_fields` = `record.fields_matching_value(query)`
     ///
     ///     >>> # Find subjects containing "History" anywhere
     ///     >>> query = mrrc.SubfieldValueQuery("650", "a", "History", partial=True)
@@ -1411,7 +1424,7 @@ impl PyRecord {
 /// They use the same ISO 2709 binary format as bibliographic records but are organized
 /// by functional role (heading, tracings, notes, etc.).
 #[pyclass(name = "AuthorityRecord", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PyAuthorityRecord {
     pub inner: AuthorityRecord,
 }
@@ -1453,7 +1466,7 @@ impl PyAuthorityRecord {
         self.inner
             .heading()
             .and_then(|f| f.get_subfield('a'))
-            .map(|s| s.to_string())
+            .map(std::string::ToString::to_string)
     }
 
     /// Get all see-from tracings (4XX fields)
@@ -1520,7 +1533,9 @@ impl PyAuthorityRecord {
 
     /// Get control field by tag
     pub fn get_control_field(&self, tag: &str) -> Option<String> {
-        self.inner.get_control_field(tag).map(|s| s.to_string())
+        self.inner
+            .get_control_field(tag)
+            .map(std::string::ToString::to_string)
     }
 
     /// Convert to JSON string
@@ -1528,10 +1543,10 @@ impl PyAuthorityRecord {
         // Authority records can be serialized like bibliographic records
         // by wrapping them in a Record structure
         // For now, convert the heading field to JSON
-        let heading_json = self
-            .heading()
-            .map(|f| format!("{{\"heading\": {}}}", f.inner.tag))
-            .unwrap_or_else(|| "{}".to_string());
+        let heading_json = self.heading().map_or_else(
+            || "{}".to_string(),
+            |f| format!("{{\"heading\": {}}}", f.inner.tag),
+        );
         Ok(heading_json)
     }
 
@@ -1557,7 +1572,7 @@ impl PyAuthorityRecord {
 /// They use the same ISO 2709 binary format as bibliographic records but organize
 /// fields by functional role (locations, enumeration, notes, etc.).
 #[pyclass(name = "HoldingsRecord", from_py_object)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PyHoldingsRecord {
     pub inner: HoldingsRecord,
 }
@@ -1707,14 +1722,16 @@ impl PyHoldingsRecord {
 
     /// Get control field by tag
     pub fn get_control_field(&self, tag: &str) -> Option<String> {
-        self.inner.get_control_field(tag).map(|s| s.to_string())
+        self.inner
+            .get_control_field(tag)
+            .map(std::string::ToString::to_string)
     }
 
     /// Convert to JSON string
     pub fn to_json(&self) -> PyResult<String> {
         // Holdings records can include location and enumeration information
         let loc_count = self.locations().len();
-        Ok(format!("{{\"locations\": {}}}", loc_count))
+        Ok(format!("{{\"locations\": {loc_count}}}"))
     }
 
     fn __repr__(&self) -> String {

--- a/src-python/src/writers.rs
+++ b/src-python/src/writers.rs
@@ -14,35 +14,37 @@ use std::io::BufWriter;
 /// Internal enum for different writer backends
 #[allow(clippy::large_enum_variant)]
 enum WriterBackend {
-    /// Python file-like object (e.g., BytesIO, open file in 'wb' mode)
+    /// Python file-like object (e.g., `BytesIO`, open file in 'wb' mode)
     /// Requires GIL for I/O operations
     PythonFile { file_obj: Py<PyAny> },
-    /// Pure Rust file I/O via std::fs::File (no GIL overhead)
+    /// Pure Rust file I/O via `std::fs::File` (no GIL overhead)
     /// Used when writer initialized with file path string
     RustFile { writer: BufWriter<File> },
 }
 
-/// Python wrapper for MarcWriter with efficient GIL release pattern
+/// Python wrapper for `MarcWriter` with efficient GIL release pattern
 ///
 /// Enables GIL release during CPU-intensive serialization:
-/// - Extract record data from Python PyRecord (GIL held)
+/// - Extract record data from Python `PyRecord` (GIL held)
 /// - Serialize record to bytes (GIL released)
 /// - Write bytes to backend (GIL management varies by backend)
 ///
 /// ## Backends
 ///
-/// **PythonFile:** File-like Python objects (BytesIO, file handles from open())
-/// - Phase 3 uses GIL (calls Python .write() method)
+/// **`PythonFile`:** File-like Python objects (`BytesIO`, file handles from `open()`)
+/// - Phase 3 uses GIL (calls Python .`write()` method)
 /// - Allows concurrent writes to different file objects
 /// - Limited concurrency due to GIL contention
 ///
-/// **RustFile:** Rust file paths (str, pathlib.Path)
+/// **`RustFile`:** Rust file paths (str, pathlib.Path)
 /// - Phase 3 uses no GIL (pure Rust I/O)
 /// - Enables near-native concurrent performance
 /// - Ideal for write-heavy workloads
 ///
 /// This allows multiple threads to write different files concurrently.
 #[pyclass(name = "MARCWriter")]
+// wraps WriterBackend which does not implement Debug
+#[allow(missing_debug_implementations)]
 pub struct PyMARCWriter {
     backend: Option<WriterBackend>,
     closed: bool,
@@ -50,12 +52,12 @@ pub struct PyMARCWriter {
 
 #[pymethods]
 impl PyMARCWriter {
-    /// Create a new MARCWriter from any supported source
+    /// Create a new `MARCWriter` from any supported source
     ///
     /// Accepts:
-    /// - str path (e.g., 'output.mrc') → RustFile backend (no GIL)
-    /// - pathlib.Path → RustFile backend (no GIL)
-    /// - Python file object → PythonFile backend (GIL managed)
+    /// - str path (e.g., 'output.mrc') → `RustFile` backend (no GIL)
+    /// - pathlib.Path → `RustFile` backend (no GIL)
+    /// - Python file object → `PythonFile` backend (GIL managed)
     ///
     /// # Arguments
     /// * `source` - File path (str), pathlib.Path, or file-like object
@@ -66,8 +68,7 @@ impl PyMARCWriter {
             // String path → open with Rust for zero-GIL I/O
             let file = File::create(&path_str).map_err(|e| {
                 pyo3::exceptions::PyIOError::new_err(format!(
-                    "Failed to open file '{}' for writing: {}",
-                    path_str, e
+                    "Failed to open file '{path_str}' for writing: {e}"
                 ))
             })?;
 
@@ -87,8 +88,7 @@ impl PyMARCWriter {
         {
             let file = File::create(&path_str).map_err(|e| {
                 pyo3::exceptions::PyIOError::new_err(format!(
-                    "Failed to open file '{}' for writing: {}",
-                    path_str, e
+                    "Failed to open file '{path_str}' for writing: {e}"
                 ))
             })?;
 
@@ -120,15 +120,15 @@ impl PyMARCWriter {
     /// Write a record to the file with efficient GIL management
     ///
     /// Implements efficient GIL release for concurrent performance:
-    /// - **Phase 1 (GIL held):** Extract record data from Python PyRecord object
+    /// - **Phase 1 (GIL held):** Extract record data from Python `PyRecord` object
     /// - **Phase 2 (GIL released):** Serialize record to MARC bytes (CPU-intensive)
     /// - **Phase 3 (GIL held):** Write serialized bytes to backend
     ///
     /// This pattern allows multiple threads to write different files concurrently:
     /// - Each thread releases the GIL during Phase 2 (serialization)
     /// - Only acquires GIL for Phase 1 (data extraction) and Phase 3 (I/O)
-    /// - RustFile backend (Phase 3) doesn't need GIL, enabling near-native performance
-    /// - PythonFile backend (Phase 3) requires GIL for calling Python .write() method
+    /// - `RustFile` backend (Phase 3) doesn't need GIL, enabling near-native performance
+    /// - `PythonFile` backend (Phase 3) requires GIL for calling Python .`write()` method
     ///
     /// # Errors
     /// - Returns error if writer has been closed
@@ -187,15 +187,13 @@ impl PyMARCWriter {
                 let file_ref = file_obj.bind(py);
                 let write_method = file_ref.getattr("write").map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "File object has no write method: {}",
-                        e
+                        "File object has no write method: {e}"
                     ))
                 })?;
 
                 write_method.call1((record_bytes,)).map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Failed to write record bytes: {}",
-                        e
+                        "Failed to write record bytes: {e}"
                     ))
                 })?;
             },
@@ -205,8 +203,7 @@ impl PyMARCWriter {
                 use std::io::Write;
                 writer.write_all(&record_bytes).map_err(|e| {
                     pyo3::exceptions::PyIOError::new_err(format!(
-                        "Failed to write record bytes: {}",
-                        e
+                        "Failed to write record bytes: {e}"
                     ))
                 })?;
             },
@@ -220,7 +217,7 @@ impl PyMARCWriter {
         Ok(())
     }
 
-    /// Alias for write_record (for pymarc compatibility)
+    /// Alias for `write_record` (for pymarc compatibility)
     pub fn write(&mut self, record: &PyRecord) -> PyResult<()> {
         self.write_record(record)
     }
@@ -231,8 +228,8 @@ impl PyMARCWriter {
     /// Safe to call multiple times (idempotent).
     ///
     /// ## GIL Management
-    /// - **PythonFile:** GIL is held while calling Python flush() method
-    /// - **RustFile:** No GIL needed (pure Rust I/O)
+    /// - **`PythonFile`:** GIL is held while calling Python `flush()` method
+    /// - **`RustFile`:** No GIL needed (pure Rust I/O)
     pub fn close(&mut self) -> PyResult<()> {
         if !self.closed {
             match &mut self.backend {


### PR DESCRIPTION
The root `Cargo.toml` is both the workspace root and the `mrrc` core package, so its `[lints.rust]`/`[lints.clippy]` tables were scoped to the core crate only — the `mrrc-python` PyO3 bindings crate (Rust under `src-python/src/`) escaped clippy entirely.

## What changed
- Promoted the lint tables to `[workspace.lints]`; both crates now inherit via `[lints] workspace = true`.
- Marked `mrrc-python` `publish = false` (it's only ever built as the `_mrrc` extension).

## Resolving the latent debt
Linting the bindings crate under `-D warnings` surfaced ~280 warnings it had never been checked against. All resolved, **with no behavior or Python API change**:
- `clippy --fix` handled the ~245 cosmetic ones (inlined `format!` args, doc backticks, redundant closures, `single_match`→`if let`, `let…else`).
- 15 binding types gained `#[derive(Debug)]`; 3 I/O-holding types (`PyMARCWriter`, `PyAuthorityMARCReader`, `PyHoldingsMARCReader`) carry a documented `#[allow(missing_debug_implementations)]` because their backend enums aren't `Debug`.
- `unsafe_code` is allowed crate-wide — PyO3 needs it for GIL/buffer crossing.
- `unnecessary_wraps` and `needless_pass_by_value` are allowed crate-wide with rationale: Python protocol methods (`__iter__`/`__exit__`/`close`/`to_json`) return `PyResult` for protocol conformance and forward-compatibility, and `#[pyfunction]` arguments are extracted by value — for the parallel parsers the owned `Vec<u8>` buffer is load-bearing, since a borrow into Python memory could be freed or mutated across the GIL release (clippy's `&[u8]` suggestion would be unsound).

This is item (a) of bd-yfe6.9. Items (b) mrk-Display and (e) wheels-vs-abi3/free-threaded eval were split out (to bd-g2xo and bd-mwhj respectively), so merging this closes bd-yfe6.9 and the `bd-yfe6` packaging epic.

Bead: bd-yfe6.9