### PR TITLE
Return the wrapped mrrc.Field from Record.remove_field_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Record.remove_field_at()` now returns the `mrrc.Field` wrapper (with `__getitem__` and the
+  other pymarc conveniences) instead of the bare `_mrrc.Field` extension type.
 - `copy.copy()` of a `Record` no longer raises `RecursionError`: the wrapper's attribute
   delegation now stops cleanly when the inner record is absent during copy reconstruction.
 - Corrected Python documentation errors that broke copy-pasted code: the README and

--- a/mrrc/__init__.py
+++ b/mrrc/__init__.py
@@ -1142,6 +1142,16 @@ class Record:
         for tag in tags:
             self._remove_tag(tag)
 
+    def remove_field_at(self, tag: str, occurrence: int = 0) -> Field:
+        """Remove the data field at ``(tag, occurrence)`` and return it.
+
+        The removed field is returned as a detached :class:`Field` wrapper —
+        it carries the pymarc conveniences (``__getitem__`` and the rest),
+        owns its data, and no longer writes through to the record — rather
+        than the bare ``_mrrc.Field`` extension type.
+        """
+        return _wrap_field(self._inner.remove_field_at(tag, occurrence))
+
     def _remove_tag(self, tag: str) -> None:
         """Remove all fields with the given tag, control tags included."""
         if _is_control_tag(tag):

--- a/tests/python/test_field_handle_writeback.py
+++ b/tests/python/test_field_handle_writeback.py
@@ -339,6 +339,15 @@ def test_deepcopy_of_leader_is_independent() -> None:
     assert duplicate.record_status == "c"
 
 
+def test_remove_field_at_returns_wrapper() -> None:
+    """``remove_field_at`` returns the mrrc.Field wrapper, not the raw type."""
+    record = _build_record()
+    removed = record.remove_field_at("245", 0)
+    assert isinstance(removed, mrrc.Field)
+    # The wrapper conveniences work; the raw _mrrc.Field lacks __getitem__.
+    assert removed["a"] == "Original title /"
+
+
 # ---------------------------------------------------------------------
 # Same-tag remove plus re-add: no occurrence aliasing
 # ---------------------------------------------------------------------


### PR DESCRIPTION
`Record.remove_field_at(tag, occurrence)` had no Python wrapper, so it delegated straight to the Rust `_Record` and handed back the bare `_mrrc.Field` extension type — which lacks `__getitem__` and the other pymarc conveniences. A caller doing `record.remove_field_at("245", 0)["a"]` got `TypeError: not subscriptable`.

## Fix
Add a `Record.remove_field_at` wrapper that returns the removed field as a **detached** `mrrc.Field` (it owns its data and no longer writes through to the record).

## Audit
The bead asked to audit `mrrc/__init__.py` for other methods leaking unwrapped extension types. Result: `remove_field_at` was the only leak —
- `get_field`, `get_fields`, `__getitem__`, `get()`, `fields()` all already return the `mrrc.Field` wrapper.
- `Field.subfields()` returns the raw type, but `mrrc.Subfield` **is** that extension type (no wrapper exists to miss), so it's not a leak.

(Noted in passing, out of scope: `iter(record)` raises a `TypeError` via the `__getitem__` sequence fallback — a separate missing-`__iter__` gap, not a type leak. Worth its own bead.)

Bead: bd-vcv3