### PR TITLE
Make Record iterable (for field in record)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Record` is now iterable: `for field in record` yields each field as a wrapped `mrrc.Field`
+  (control and data, in record order), matching pymarc. It previously raised `TypeError`.
 - `Record.remove_field_at()` now returns the `mrrc.Field` wrapper (with `__getitem__` and the
   other pymarc conveniences) instead of the bare `_mrrc.Field` extension type.
 - `copy.copy()` of a `Record` no longer raises `RecursionError`: the wrapper's attribute

--- a/mrrc/__init__.py
+++ b/mrrc/__init__.py
@@ -1035,6 +1035,14 @@ class Record:
             return self._inner.control_field(tag) is not None
         return self.get_field(tag) is not None
 
+    def __iter__(self):
+        """Iterate over all fields (control and data) as live handles.
+
+        Matches pymarc's ``for field in record``: yields the same wrapped
+        :class:`Field` handles as :meth:`fields`, in record order.
+        """
+        return iter(self.fields())
+
     def __getitem__(self, tag: str) -> 'Field':
          """Get first field with given tag (pymarc compatibility).
 

--- a/tests/python/test_field_handle_writeback.py
+++ b/tests/python/test_field_handle_writeback.py
@@ -348,6 +348,18 @@ def test_remove_field_at_returns_wrapper() -> None:
     assert removed["a"] == "Original title /"
 
 
+def test_record_is_iterable() -> None:
+    """``for field in record`` yields all fields as wrapped mrrc.Field handles."""
+    record = _build_record()  # 001, 005, 245, three 650s
+    fields = list(record)
+    assert len(fields) == 6
+    assert all(isinstance(f, mrrc.Field) for f in fields)
+    assert {f.tag for f in fields} == {"001", "005", "245", "650"}
+    # Yielded fields carry the pymarc conveniences (raw _mrrc.Field would not).
+    title = next(f for f in record if f.tag == "245")
+    assert title["a"] == "Original title /"
+
+
 # ---------------------------------------------------------------------
 # Same-tag remove plus re-add: no occurrence aliasing
 # ---------------------------------------------------------------------


### PR DESCRIPTION
`Record` defined `__getitem__(tag)` (string-keyed) but no `__iter__`, so `for field in record` / `list(record)` fell through to Python's old sequence protocol — calling `__getitem__(0)`, `__getitem__(1)`, … — and raised `TypeError: '<' not supported between instances of 'int' and 'str'` when the integer index hit the tag-comparison logic. pymarc Records *are* iterable, so this was a pymarc-compat gap.

## Fix
Add `Record.__iter__` that yields all fields (control and data) as wrapped `mrrc.Field` handles, delegating to the existing `fields()`.

## Ordering note
Iteration uses mrrc's canonical field order (control-first, the same order `fields()`/`get_fields()` already return), so it yields e.g. `['001', '245']`. This matches pymarc for parsed and well-formed records (control fields first); it differs from pymarc's pure insertion order only in the unusual case of a data field added before a control field. mrrc stores control and data fields separately by design, so this is consistent with the rest of the wrapper rather than a special case.

Bead: bd-zvly