### PR TITLE
Make test and lint gate every PR, then require them on main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,24 +1,13 @@
 name: Lint and Format
 
 on:
+  # No paths-ignore here: these jobs are required status checks on the main
+  # ruleset. A workflow skipped by a path filter never reports its check, which
+  # leaves the required check pending forever and makes the PR unmergeable.
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.beads/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.beads/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,24 +1,13 @@
 name: Tests
 
 on:
+  # No paths-ignore here: these jobs are required status checks on the main
+  # ruleset. A workflow skipped by a path filter never reports its check, which
+  # leaves the required check pending forever and makes the PR unmergeable.
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.beads/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.beads/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Remove `paths-ignore` from the Tests and Lint workflows so they run on every PR, and (in a follow-up step on the ruleset) require their ten checks on the `main` branch ruleset.

## Why

The `main` ruleset only enforced `deletion` + `non_fast_forward`, so the PR check gate was entirely advisory — a red PR could be merged. The fix is required status checks, but those interact badly with `paths-ignore`: a workflow skipped by a path filter never reports its check, so a required check stays pending forever and the PR becomes unmergeable. The Tests, Lint, and several other workflows were slimmed with `paths-ignore` to skip docs-only changes, which is what blocked turning the gate on.

This drops `paths-ignore` from only the two workflows whose checks we want to require, so they always report a status. The heavier wheel-build matrix, security audit, and benchmark workflows keep their path filters and stay advisory — most of the docs-only CI slimming is preserved. The expensive multi-OS wheel builds still skip docs-only PRs.

## Required checks (applied to the ruleset after this PR's CI is green)

`Test Suite (ubuntu-latest)`, `Test Suite (macos-latest)`, `Test Suite (windows-2025)`, `Rustfmt`, `Clippy`, `Documentation`, `Ruff (Python lint)`, `Stubtest (.pyi vs compiled extension)`, `Type check (mypy + pyright on mrrc/)`, `MSRV check`.

Checks behind `paths:` include-filters (CHANGELOG lint, Semver checks) are deliberately *not* required — they would hit the same skipped-check deadlock on any PR that does not touch their trigger paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Bead: bd-9cux