### PR TITLE
Drop per-record allocations in the Python read wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Control fields come back in record order rather than fixed ascending-tag order (a
   difference only for records whose control fields are stored out of order; record order
   matches pymarc).
+- Iterating a `MARCReader` is faster: wrapping each parsed record no longer builds a
+  throwaway inner `_Record` and two `_Leader` objects only to discard them, lifting
+  per-record read throughput (path and bytes inputs alike). Output is unchanged.
 - Writing ISO 2709 records (`MARCWriter` and the authority/holdings writers) allocates less:
   each directory entry's length and start-position digits are written straight into the
   output buffer instead of through a per-field `format!`.

--- a/mrrc/__init__.py
+++ b/mrrc/__init__.py
@@ -1965,10 +1965,16 @@ class MARCWriter:
 
 
 def _wrap_record(rust_record) -> Record:
-    """Wrap a raw Rust PyRecord in the Python Record wrapper."""
-    wrapper = Record(None)
+    """Wrap a raw Rust PyRecord in the Python Record wrapper.
+
+    Uses ``__new__`` to bypass the ``Record`` and ``Leader`` constructors,
+    which would each build a throwaway inner Rust object (``_Record`` and
+    ``_Leader``) only to have it discarded here. This wrapping runs once per
+    record on the read hot path, so the saved allocations matter.
+    """
+    wrapper = Record.__new__(Record)
     wrapper._inner = rust_record
-    leader = Leader()
+    leader = object.__new__(Leader)
     leader._rust_leader = rust_record.leader
     leader._parent_record = wrapper
     wrapper._leader = leader


### PR DESCRIPTION
## What

`_wrap_record` builds each parsed record via `Record(None)` + `Leader()`, whose constructors each allocate a throwaway inner Rust object (`_Record`, `_Leader`) that is immediately discarded — two `_Leader` + one `_Record` allocation per record, for nothing, on the read hot path. This builds the wrapper with `__new__` instead (the pattern `Record.__deepcopy__` already uses) and sets `_inner` / `_rust_leader` directly.

## Impact (per-record `MARCReader` iteration)

| fixture | before | after | vs pymarc |
|---|---:|---:|---:|
| realistic 18-field | 43.7k rec/s | **49.2k (+13%)** | 0.92x → **1.48x** |
| synthetic 6-field | 96.6k rec/s | **120k (+24%)** | 0.91x → **1.13x** |

After the fix the wrapper (49.2k) sits at the raw-Rust per-record ceiling (50.0k), so `_wrap_record` was the dominant per-record wrapper tax. Output is unchanged; 908 Python tests pass.

## Context

Surfaced by the bd-dra6 comparison harness (#352). Note this lifts the *per-record* path; the headline multi-x speedup over pymarc is the bulk `parse_batch_parallel` path (3.6–4.4x on realistic records), and pushing per-record iteration toward bulk speed is tracked separately in bd-kpl9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Bead: bd-rblu