### PR TITLE
Publish a three-way benchmark: pymarc, the Python wrapper, and native Rust

### DIFF
--- a/docs/benchmarks/results.md
+++ b/docs/benchmarks/results.md
@@ -1,31 +1,59 @@
 # Benchmark Results
 
-## mrrc vs pymarc (Python)
+## pymarc, the Python wrapper, and native Rust
 
-Measured with `scripts/benchmark_comparison.py` against a pinned pymarc over
-the same records. These figures come from a single host — an Apple M4 MacBook
-Air, a working development laptop rather than a dedicated benchmark rig — so
-read them as the *relative* speedup, not an absolute maximum. The read figures
-vary run-to-run on a busy machine; extract and roundtrip are steady.
+mrrc has two front doors — a pymarc-compatible Python API and the native Rust
+crate — so the honest comparison is three-way: the mature pure-Python library,
+the wrapper a Python user actually calls, and the Rust ceiling underneath it.
+All three are measured over the same records by
+`scripts/benchmark_comparison.py` (the native column via
+`examples/benchmark_native`). Every figure is **median records per second**
+(rec/s); they come from a single host — an Apple M4 laptop, a working
+development machine rather than a dedicated benchmark rig — so read them as
+*relative* throughput, not absolute maxima; `read` in particular varies
+run-to-run on a busy machine.
 
-| Operation | mrrc | pymarc | speedup |
-|-----------|-----:|-------:|--------:|
-| read — per-record (`for r in reader`) | ~190–255k rec/s | ~30–32k rec/s | **~6–8×** |
-| read_bulk — `parse_batch_parallel` (parallel) | ~0.8–1.2M rec/s | ~32k rec/s | **~26–36×** |
-| extract — title + every subfield value | ~44k rec/s | ~26k rec/s | **~1.7×** |
-| roundtrip — `as_marc()` | ~140k rec/s | ~21k rec/s | **~7×** |
+| Operation | pymarc (rec/s) | mrrc Python (rec/s) | mrrc Rust (rec/s) | Python vs pymarc | Rust vs pymarc |
+|-----------|---------------:|--------------------:|------------------:|-----------------:|---------------:|
+| `read` | ~32k | ~225k | ~289k | **~7×** | **~9×** |
+| `read_bulk` | ~32k | ~977k | ~1.10M | **~31×** | **~35×** |
+| `extract` | ~27k | ~44k | ~255k | **~1.6×** | **~9×** |
+| `roundtrip` | ~21k | ~138k | ~184k | **~6.5×** | **~8.5×** |
+
+- `read` — per-record iteration (`for r in reader`), no field access.
+- `read_bulk` — mrrc's parallel `parse_batch_parallel` against pymarc's
+  per-record read (pymarc has no batch equivalent); each library's fastest read.
+- `extract` — `record.title` plus `field.value()` for every field.
+- `roundtrip` — re-encode each record with `as_marc()`.
+
+**Both speedup columns use the same pymarc baseline, but the two mrrc columns
+do different work.** pymarc and mrrc (Python) both parse and hand back Python
+objects, so *Python vs pymarc* is a like-for-like speedup. mrrc (Rust) parses to
+Rust records and stops — it never builds Python objects — so *Rust vs pymarc* is
+the native ceiling. The distance between the two multipliers (`~7×` vs `~9×` for
+`read`) is the cost of the Python binding: crossing the PyO3 boundary and
+materializing `Record`/`Field` objects, not extra parsing work.
+
+That distance is the useful part. For `read`, `read_bulk`, and `roundtrip` the
+two multipliers sit close together — the wrapper captures roughly 75–88% of the
+native throughput, because field handles are lazy and the bulk path is a thin
+shim over the same parallel Rust parse, so a Python user gives up little.
+`extract` is the exception: touching every field's value crosses the boundary
+per field, so the wrapper reaches only `~1.6×` against `~9×` native — pure Rust
+pulls roughly 5–6× ahead. If per-field access dominates your workload and you
+need the ceiling, that is the case for reaching for the Rust crate directly.
+
+pymarc remains the reference implementation: mature, flexible, pure Python. The
+multipliers here reflect native parsing and the absence of per-record Python
+object construction, not a verdict on pymarc — for many Python codebases the
+wrapper's drop-in compatibility with it is the whole point.
 
 Context: Apple M4 (10 cores, 24 GiB), macOS 26.5, Python 3.14, rustc 1.95, a
 **release** build of mrrc 0.8.x, pymarc 5.3.1, over a 2,000-record realistic
-fixture (`tests/data/fixtures/realistic.mrc`, ~1.1 KB/record). `read_bulk` pits
-mrrc's parallel batch parse against pymarc's per-record read — each library's
-fastest read path; pymarc has no batch equivalent.
-
-Two things to know: `read`/`read_bulk` lean hardest on the Rust parser, while
-`extract` (the field-handle access path) is the relative weak spot. And the
-build profile matters — a debug build is several times slower, so a release
-build (`maturin develop --release`, or any published wheel) is required to
-reproduce these.
+fixture (`tests/data/fixtures/realistic.mrc`, ~1.1 KB/record). The build profile
+matters — a debug build is several times slower, so a release build
+(`maturin develop --release`, or any published wheel) is required to reproduce
+these.
 
 ### Reproducing this comparison
 
@@ -38,6 +66,10 @@ uv run python scripts/generate_realistic_fixture.py
 .venv/bin/python scripts/benchmark_comparison.py \
     tests/data/fixtures/realistic.mrc --repeat 9 --output tmp/comparison-results.md
 ```
+
+The harness builds and runs `examples/benchmark_native` (via `cargo run
+--release`) for the native column; pass `--no-native` to drop it where a Rust
+toolchain is unavailable.
 
 The sections below describe what CI measures and the broader benchmarking setup.
 
@@ -125,6 +157,8 @@ library data (a real corpus).
 
 ## References
 
+- Three-way comparison harness: `scripts/benchmark_comparison.py` (Python +
+  pymarc) and `examples/benchmark_native.rs` (native Rust ceiling)
 - Rust benchmarks: `benches/marc_benchmarks.rs`,
   `benches/error_handling_benchmarks.rs`, `benches/parallel_benchmarks.rs`
 - Python benchmarks: `tests/python/test_benchmark_*.py`

--- a/examples/benchmark_native.rs
+++ b/examples/benchmark_native.rs
@@ -1,0 +1,212 @@
+//! Pure-Rust wall-clock throughput harness, the native-ceiling column behind
+//! the three-way comparison in `docs/benchmarks/results.md`.
+//!
+//! It mirrors, operation for operation, what `scripts/benchmark_comparison.py`
+//! measures for the mrrc Python wrapper and pymarc — over the same fixture —
+//! so the three numbers sit in one table. The difference between this column
+//! and the Python wrapper is the cost of crossing into Python and building
+//! Python objects: this harness parses to Rust `Record`s and stops; the
+//! wrapper additionally materializes Python `Record`/`Field` objects.
+//!
+//! `scripts/benchmark_comparison.py` invokes this with `--json` and merges the
+//! result. Run it directly with:
+//!
+//! ```text
+//! cargo run --release --example benchmark_native -- \
+//!     tests/data/fixtures/realistic.mrc --repeat 9
+//! ```
+//!
+//! Wall-clock numbers are only worth citing from a quiet machine on AC power.
+
+use std::path::Path;
+use std::time::Instant;
+
+use mrrc::boundary_scanner::RecordBoundaryScanner;
+use mrrc::rayon_parser_pool::parse_batch_parallel;
+use mrrc::{MarcReader, MarcWriter, RecordHelpers};
+
+/// Each op does one full pass over the file and returns
+/// (`record_count`, `elapsed_seconds`), matching its Python counterpart.
+type Op = fn(&Path) -> (usize, f64);
+
+/// `read` — parse every record, no field access. Mirrors `for r in reader`.
+fn op_read(path: &Path) -> (usize, f64) {
+    let start = Instant::now();
+    let mut reader = MarcReader::from_path(path).expect("open fixture");
+    let mut count = 0usize;
+    while let Some(_record) = reader.read_record().expect("read record") {
+        count += 1;
+    }
+    (count, start.elapsed().as_secs_f64())
+}
+
+/// `read_bulk` — scan boundaries and parse the whole file in one parallel
+/// rayon call, mrrc's fastest read path. Mirrors `parse_batch_parallel`.
+fn op_read_bulk(path: &Path) -> (usize, f64) {
+    let start = Instant::now();
+    let buffer = std::fs::read(path).expect("read fixture");
+    let mut scanner = RecordBoundaryScanner::new();
+    let boundaries = scanner.scan(&buffer).expect("scan boundaries");
+    let records = parse_batch_parallel(&boundaries, &buffer).expect("parse batch");
+    (records.len(), start.elapsed().as_secs_f64())
+}
+
+/// `extract` — parse, then touch fields the way the Python `extract` op does:
+/// `record.title` plus `field.value()` for every field (control and data).
+fn op_extract(path: &Path) -> (usize, f64) {
+    let start = Instant::now();
+    let mut reader = MarcReader::from_path(path).expect("open fixture");
+    let mut count = 0usize;
+    let mut acc = 0usize;
+    while let Some(record) = reader.read_record().expect("read record") {
+        count += 1;
+        if let Some(title) = record.title() {
+            acc += title.len();
+        }
+        // Control fields: their value is the data string itself (the wrapper's
+        // `field.value()` returns `_data` for control fields).
+        for values in record.control_fields.values() {
+            for value in values {
+                acc += value.len();
+            }
+        }
+        // Data fields: value is the space-joined subfield values.
+        for field in record.fields() {
+            acc += field.value().len();
+        }
+    }
+    std::hint::black_box(acc);
+    (count, start.elapsed().as_secs_f64())
+}
+
+/// `roundtrip` — parse, then re-encode each record to ISO 2709 bytes.
+/// Mirrors `record.as_marc()` per record.
+fn op_roundtrip(path: &Path) -> (usize, f64) {
+    let start = Instant::now();
+    let mut reader = MarcReader::from_path(path).expect("open fixture");
+    let mut count = 0usize;
+    let mut acc = 0usize;
+    while let Some(record) = reader.read_record().expect("read record") {
+        count += 1;
+        let mut buffer = Vec::new();
+        {
+            let mut writer = MarcWriter::new(&mut buffer);
+            writer.write_record(&record).expect("serialize record");
+        }
+        acc += buffer.len();
+    }
+    std::hint::black_box(acc);
+    (count, start.elapsed().as_secs_f64())
+}
+
+fn op_by_name(name: &str) -> Option<Op> {
+    match name {
+        "read" => Some(op_read),
+        "read_bulk" => Some(op_read_bulk),
+        "extract" => Some(op_extract),
+        "roundtrip" => Some(op_roundtrip),
+        _ => None,
+    }
+}
+
+/// Median of `repeat` measured repetitions after discarding one cache-warming
+/// run — the same protocol as the Python harness. For an even count, average
+/// the two middle values (matching Python's `statistics.median`).
+// Record counts are small; the usize -> f64 cast for rec/s is exact in practice.
+#[allow(clippy::cast_precision_loss)]
+fn measure(op: Op, path: &Path, repeat: usize) -> (usize, f64) {
+    let (warm_count, _) = op(path); // discard the cache-warming repetition
+    let mut count = warm_count;
+    let mut rates: Vec<f64> = Vec::with_capacity(repeat);
+    for _ in 0..repeat {
+        let (n, elapsed) = op(path);
+        if n != count {
+            eprintln!("record count changed between runs ({count} vs {n}); aborting");
+            std::process::exit(1);
+        }
+        count = n;
+        rates.push(if elapsed > 0.0 {
+            n as f64 / elapsed
+        } else {
+            0.0
+        });
+    }
+    rates.sort_by(|a, b| a.partial_cmp(b).expect("no NaN rates"));
+    let mid = rates.len() / 2;
+    let median = if rates.len() % 2 == 1 {
+        rates[mid]
+    } else {
+        f64::midpoint(rates[mid - 1], rates[mid])
+    };
+    (count, median)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut path: Option<String> = None;
+    let mut repeat = 9usize;
+    let mut ops_arg = "read,read_bulk,extract,roundtrip".to_string();
+    let mut json = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--repeat" => {
+                i += 1;
+                repeat = args.get(i).and_then(|v| v.parse().ok()).unwrap_or(repeat);
+            },
+            "--ops" => {
+                i += 1;
+                if let Some(v) = args.get(i) {
+                    ops_arg.clone_from(v);
+                }
+            },
+            "--json" => json = true,
+            other if !other.starts_with("--") => path = Some(other.to_string()),
+            other => {
+                eprintln!("unknown argument: {other}");
+                std::process::exit(2);
+            },
+        }
+        i += 1;
+    }
+
+    let path = path.unwrap_or_else(|| {
+        eprintln!(
+            "usage: benchmark_native <fixture.mrc> [--repeat N] \
+             [--ops read,read_bulk,extract,roundtrip] [--json]"
+        );
+        std::process::exit(2);
+    });
+    let path = Path::new(&path);
+    if !path.exists() {
+        eprintln!("no such file: {}", path.display());
+        std::process::exit(2);
+    }
+
+    let op_names: Vec<&str> = ops_arg
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    let mut results: Vec<(String, usize, f64)> = Vec::new();
+    for name in &op_names {
+        let op = op_by_name(name).unwrap_or_else(|| {
+            eprintln!("unknown operation: {name}");
+            std::process::exit(2);
+        });
+        let (count, rate) = measure(op, path, repeat);
+        eprintln!("  {name:<10} mrrc (Rust) {rate:>14.0} rec/s  ({count} records)");
+        results.push((name.to_string(), count, rate));
+    }
+
+    if json {
+        let body: Vec<String> = results
+            .iter()
+            .map(|(name, count, rate)| {
+                format!("\"{name}\":{{\"count\":{count},\"rec_s\":{rate:.1}}}")
+            })
+            .collect();
+        println!("{{{}}}", body.join(","));
+    }
+}

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python3
-"""Compare wall-clock throughput of mrrc (pymrrc) against pymarc.
+"""Compare wall-clock throughput of pymarc, the mrrc Python wrapper, and mrrc's
+native Rust path over identical fixtures and operations.
 
-This is the Python-to-Python comparison behind any "Nx pymarc" claim: it
-measures the mrrc Python wrapper against a pinned pymarc over identical
-fixtures and operations, and emits a Markdown report carrying the full
-run context that ``docs/benchmarks/results.md`` requires for a citable
-figure.
+This is the harness behind the three-way comparison in
+``docs/benchmarks/results.md``. It measures three columns over the same records:
 
-Absolute Rust-library throughput is a *separate* measurement
-(``cargo bench --bench marc_benchmarks``). Rust-vs-Python is not an
-apples-to-apples comparison, so it is deliberately out of scope here.
+* **pymarc** — the mature pure-Python reference library.
+* **mrrc (Python)** — the wrapper a Python user actually calls: it parses in
+  Rust, then materializes Python ``Record``/``Field`` objects across the PyO3
+  boundary.
+* **mrrc (Rust)** — the native ceiling, measured by ``examples/benchmark_native``
+  (run via ``cargo run --release``). It parses to Rust ``Record``s and stops; it
+  does *not* build Python objects.
+
+The gap between the two mrrc columns is therefore the cost of the Python binding
+(boundary crossings plus object materialization), not a same-task speedup — read
+it as how close the wrapper gets to the native ceiling. Pass ``--no-native`` to
+drop the Rust column where a Rust toolchain is unavailable.
 
 Operations, each applied to every record in the file:
 
@@ -42,6 +49,7 @@ from __future__ import annotations
 import argparse
 import datetime
 import importlib.metadata
+import json
 import os
 import platform
 import statistics
@@ -164,6 +172,53 @@ OPERATIONS = {
 }
 
 
+# --- native (pure-Rust) ceiling -------------------------------------------
+#
+# The native column comes from `examples/benchmark_native`, which mirrors the
+# operations above against the same fixture. It is a separate process built and
+# run by cargo, so the comparison is median-vs-median across processes (each is
+# internally consistent). The Rust example uses the same warm-discard + median
+# protocol and the same --repeat as the Python measurements.
+
+
+def native_measure(
+    path: Path, repeat: int, ops: list[str]
+) -> dict[str, tuple[int, float]]:
+    """Return {op: (count, rec/s)} from the pure-Rust harness, or exit."""
+    cmd = [
+        "cargo",
+        "run",
+        "--release",
+        "--quiet",
+        "--example",
+        "benchmark_native",
+        "--",
+        str(path),
+        "--repeat",
+        str(repeat),
+        "--ops",
+        ",".join(ops),
+        "--json",
+    ]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except FileNotFoundError:
+        sys.exit(
+            "cargo not found; the native Rust column needs a Rust toolchain. "
+            "Re-run with --no-native to skip it."
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.exit(
+            f"native harness failed (exit {exc.returncode}):\n{exc.stderr}\n"
+            "Re-run with --no-native to skip the Rust column."
+        )
+    payload = out.stdout.strip().splitlines()
+    if not payload:
+        sys.exit("native harness produced no output")
+    data = json.loads(payload[-1])
+    return {op: (cell["count"], cell["rec_s"]) for op, cell in data.items()}
+
+
 # --- measurement ----------------------------------------------------------
 
 
@@ -277,14 +332,16 @@ def human_size(path: Path) -> str:
     size = path.stat().st_size
     for unit in ("B", "KB", "MB", "GB"):
         if size < 1024 or unit == "GB":
-            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+            return (
+                f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+            )
         size /= 1024
     return f"{size:.1f} GB"
 
 
-def render_markdown(context, fixtures, results, repeat) -> str:
+def render_markdown(context, fixtures, results, repeat, native: bool) -> str:
     lines = [
-        f"## mrrc vs pymarc — {context['Date'][:10]}",
+        f"## pymarc vs mrrc — {context['Date'][:10]}",
         "",
         "**Run context**",
         "",
@@ -296,9 +353,23 @@ def render_markdown(context, fixtures, results, repeat) -> str:
         "host above — a working machine, not a dedicated benchmark rig, so "
         "treat the figures as representative of the relative speedup rather "
         "than a sterile maximum.",
-        "- Comparison is Python-to-Python (mrrc wrapper vs pymarc). Absolute "
-        "Rust throughput is measured separately via "
-        "`cargo bench --bench marc_benchmarks`.",
+    ]
+    if native:
+        lines += [
+            "- Three columns: **pymarc** (pure Python), **mrrc (Python)** (the "
+            "wrapper — parses in Rust, then builds Python objects), and **mrrc "
+            "(Rust)** (the native ceiling — parses to Rust records, no Python "
+            "objects). Both speedups are vs the same pymarc baseline; the gap "
+            "between *Python vs pymarc* and *Rust vs pymarc* is the Python "
+            "binding overhead (how much native headroom the wrapper leaves), "
+            "not extra parsing work.",
+        ]
+    else:
+        lines += [
+            "- Comparison is Python-to-Python (mrrc wrapper vs pymarc). The "
+            "native Rust ceiling is omitted (`--no-native`).",
+        ]
+    lines += [
         "- `read` = per-record iteration (`for r in reader`), the pymarc-shaped "
         "path. `read_bulk` = mrrc's parallel `parse_batch_parallel` vs pymarc's "
         "per-record read — each library's fastest read path.",
@@ -310,20 +381,50 @@ def render_markdown(context, fixtures, results, repeat) -> str:
             f"### {path.name} — {fixture['count']:,} records "
             f"({human_size(path)})",
             "",
-            "| Operation | mrrc (rec/s) | pymarc (rec/s) | speedup |",
-            "|-----------|-------------:|---------------:|--------:|",
         ]
-        for op_name in fixture["ops"]:
-            cell = results[(path, op_name)]
-            speed = (
-                f"{cell['mrrc'] / cell['pymarc']:.2f}x"
-                if cell["pymarc"]
-                else "n/a"
-            )
-            lines.append(
-                f"| {op_name} | {cell['mrrc']:,.0f} | "
-                f"{cell['pymarc']:,.0f} | {speed} |"
-            )
+        if native:
+            lines += [
+                "| Operation | pymarc (rec/s) | mrrc Python (rec/s) | "
+                "mrrc Rust (rec/s) | Python vs pymarc | Rust vs pymarc |",
+                "|-----------|---------------:|--------------------:|"
+                "-----------------:|-----------------:|---------------:|",
+            ]
+            for op_name in fixture["ops"]:
+                cell = results[(path, op_name)]
+                py_speed = (
+                    f"{cell['mrrc'] / cell['pymarc']:.1f}x"
+                    if cell["pymarc"]
+                    else "n/a"
+                )
+                rust_speed = (
+                    f"{cell['native'] / cell['pymarc']:.1f}x"
+                    if cell["pymarc"] and cell["native"]
+                    else "n/a"
+                )
+                native_cell = (
+                    f"{cell['native']:,.0f}" if cell["native"] else "n/a"
+                )
+                lines.append(
+                    f"| {op_name} | {cell['pymarc']:,.0f} | "
+                    f"{cell['mrrc']:,.0f} | {native_cell} | {py_speed} | "
+                    f"{rust_speed} |"
+                )
+        else:
+            lines += [
+                "| Operation | mrrc (rec/s) | pymarc (rec/s) | speedup |",
+                "|-----------|-------------:|---------------:|--------:|",
+            ]
+            for op_name in fixture["ops"]:
+                cell = results[(path, op_name)]
+                speed = (
+                    f"{cell['mrrc'] / cell['pymarc']:.2f}x"
+                    if cell["pymarc"]
+                    else "n/a"
+                )
+                lines.append(
+                    f"| {op_name} | {cell['mrrc']:,.0f} | "
+                    f"{cell['pymarc']:,.0f} | {speed} |"
+                )
         lines.append("")
     return "\n".join(lines)
 
@@ -354,6 +455,11 @@ def main() -> None:
         "discarding it",
     )
     parser.add_argument(
+        "--no-native",
+        action="store_true",
+        help="skip the native Rust ceiling column (no Rust toolchain needed)",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         help="write the Markdown report here (also printed to stdout)",
@@ -374,11 +480,13 @@ def main() -> None:
     for key, value in context.items():
         print(f"  {key}: {value}", file=sys.stderr)
 
+    native_on = not args.no_native
     fixtures = []
     results: dict[tuple[Path, str], dict[str, float]] = {}
     for path in args.files:
         print(f"\n{path} ({human_size(path)})", file=sys.stderr)
         counts: set[int] = set()
+        native = native_measure(path, args.repeat, ops) if native_on else {}
         for op_name in ops:
             mrrc_op, pymarc_op = OPERATIONS[op_name]
             m_count, m_rates = measure(
@@ -390,14 +498,19 @@ def main() -> None:
             counts.update({m_count, p_count})
             m_median = statistics.median(m_rates)
             p_median = statistics.median(p_rates)
+            n_count, n_median = native.get(op_name, (None, None))
+            if n_count is not None:
+                counts.add(n_count)
             results[(path, op_name)] = {
                 "mrrc": m_median,
                 "pymarc": p_median,
+                "native": n_median,
             }
             speed = m_median / p_median if p_median else float("nan")
+            native_str = f"  native {n_median:>12,.0f}" if n_median else ""
             print(
-                f"  {op_name:<10} mrrc {m_median:>12,.0f}  "
-                f"pymarc {p_median:>12,.0f}  ({speed:.2f}x)",
+                f"  {op_name:<10} pymarc {p_median:>12,.0f}  "
+                f"mrrc {m_median:>12,.0f}{native_str}  ({speed:.2f}x)",
                 file=sys.stderr,
             )
             if m_count != p_count:
@@ -407,11 +520,11 @@ def main() -> None:
                     "for this fixture is not apples-to-apples.",
                     file=sys.stderr,
                 )
-        fixtures.append(
-            {"path": path, "count": max(counts), "ops": ops}
-        )
+        fixtures.append({"path": path, "count": max(counts), "ops": ops})
 
-    report = render_markdown(context, fixtures, results, args.repeat)
+    report = render_markdown(
+        context, fixtures, results, args.repeat, native_on
+    )
     print("\n" + report)
     if args.output:
         args.output.write_text(report + "\n")


### PR DESCRIPTION
The published comparison only pitted the mrrc Python wrapper against pymarc. This adds the **native Rust path** as a third column so the doc shows the ceiling — and how close the wrapper gets to it.

## What changed

- **`examples/benchmark_native.rs`** — a pure-Rust wall-clock harness mirroring the four operations (`read`, `read_bulk`, `extract`, `roundtrip`) over the same `realistic.mrc` fixture, reporting median rec/s with the same warm-discard protocol as the Python harness.
- **`scripts/benchmark_comparison.py`** — now builds and runs the native harness (`cargo run --release`) and renders a three-column table; `--no-native` drops the Rust column where no Rust toolchain is available.
- **`docs/benchmarks/results.md`** — three-way table (pymarc / mrrc Python / mrrc Rust), with both speedups measured against the same pymarc baseline so nothing mixes units, and the unit (median rec/s) stated in prose and the value-column headers.

## The story the numbers tell

| Operation | pymarc | mrrc Python | mrrc Rust | Python vs pymarc | Rust vs pymarc |
|-----------|-------:|------------:|----------:|-----------------:|---------------:|
| `read` | ~32k | ~225k | ~289k | ~7× | ~9× |
| `read_bulk` | ~32k | ~977k | ~1.10M | ~31× | ~35× |
| `extract` | ~27k | ~44k | ~255k | ~1.6× | ~9× |
| `roundtrip` | ~21k | ~138k | ~184k | ~6.5× | ~8.5× |

The wrapper rides at ~75–88% of the native ceiling for `read`/`read_bulk`/`roundtrip` (lazy field handles, thin bulk shim), but only ~17% for `extract` — per-field boundary crossings are where pure Rust pulls ~5–6× ahead. The doc frames pymarc as the mature reference implementation; the multipliers reflect native parsing and no per-record Python object construction, not a knock on pymarc.

## Verification

- `examples/benchmark_native` runs clean under `clippy --all-targets -- -D warnings`; `cargo fmt` clean.
- The harness passes ruff; the doc builds under `mkdocs --strict`.
- Numbers are a median-of-9 run on an Apple M4 (release build, pymarc 5.3.1), context recorded in the doc.

This also produces the measured figures that the v0.9.0 doc-accuracy fix (bd-t1vf.1) will reference when correcting the obsolete benchmark hedge on the other docs pages.