### PR TITLE
Fix stale CI badges in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Tests](https://github.com/dchud/mrrc/actions/workflows/test.yml/badge.svg)](https://github.com/dchud/mrrc/actions/workflows/test.yml)
 [![Lint](https://github.com/dchud/mrrc/actions/workflows/lint.yml/badge.svg)](https://github.com/dchud/mrrc/actions/workflows/lint.yml)
-[![Build](https://github.com/dchud/mrrc/actions/workflows/build.yml/badge.svg)](https://github.com/dchud/mrrc/actions/workflows/build.yml)
-[![codecov](https://codecov.io/gh/dchud/mrrc/branch/main/graph/badge.svg)](https://codecov.io/gh/dchud/mrrc)
+[![Build](https://github.com/dchud/mrrc/actions/workflows/python-build.yml/badge.svg)](https://github.com/dchud/mrrc/actions/workflows/python-build.yml)
 [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json?org=dchud&repo=mrrc)](https://codspeed.io/dchud/mrrc)
 
 A Rust library for reading, writing, and manipulating MARC bibliographic records, with Python bindings.


### PR DESCRIPTION
Two README badges no longer reflect reality after earlier CI changes:

- **Build** pointed at `build.yml`, which was folded into `python-build.yml` — that workflow is gone, so GitHub served a literal **404** image. Repointed to `python-build.yml` ("Python Wheel Build & Test"), which builds and tests the wheels on every PR.
- **codecov** — coverage moved to `cargo llvm-cov` + pytest-cov reporting into the CI job summary with **no external service** (`coverage.yml` states this), and nothing is wired to codecov. The badge returns HTTP 200 but renders a permanent "unknown", so it is removed rather than repointed (there is no external coverage service to point at).

Remaining badges — Tests (`test.yml`), Lint (`lint.yml`), Build (`python-build.yml`), CodSpeed — all resolve 200. Easy to restore the codecov badge later if an external coverage service is ever wired up.