### PR TITLE
Guard batch-boundary overflow and fuzz the byte-source parse path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously produced a malformed 13-byte entry; it now returns a `WriterError`
   naming the offending tag. Affects the bibliographic, authority, and holdings
   writers.
+- `parse_batch_parallel` (Rust and the Python extension) now returns a
+  `MarcError` instead of panicking when given record boundaries whose
+  `offset + length` exceeds the buffer or overflows `usize`. The function takes
+  caller-supplied boundaries; values from `RecordBoundaryScanner` are always in
+  range, so this only affects callers passing boundaries directly.
 
 ### Performance
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,6 +34,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "parse_record_from_bytes"
+path = "fuzz_targets/parse_record_from_bytes.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "roundtrip_binary"
 path = "fuzz_targets/roundtrip_binary.rs"
 test = false

--- a/fuzz/fuzz_targets/parse_record_from_bytes.rs
+++ b/fuzz/fuzz_targets/parse_record_from_bytes.rs
@@ -1,0 +1,48 @@
+//! Byte-source parse fuzz harness.
+//!
+//! Drives the in-memory byte-source entry points — `parse_record_from_bytes`
+//! and `parse_record_from_shared_bytes` — over arbitrary bytes in every
+//! recovery mode and validation level. These reach
+//! `parse_iso2709_record_from_bytes` (the leader-length guard, the
+//! truncated-body copy, and the `LEADER_LEN..LEADER_LEN + expected_data_len`
+//! slice) — divergent code the reader-driven targets (`parse_record`,
+//! `roundtrip_binary`, `recovery_mode_consistency`) never exercise.
+//! `parse_record_from_shared_bytes` is the production Python read path (the
+//! src-python batched reader), so a panic here is a panic users could hit.
+//!
+//! An `Err(MarcError)` on malformed input is correct behavior, not a bug, so
+//! the results are discarded — libfuzzer only flags panics, OOMs, and
+//! timeouts.
+//!
+//! See `docs/contributing/fuzzing.md` for triage.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use mrrc::{
+    RecoveryMode, ValidationLevel, parse_record_from_bytes,
+    parse_record_from_shared_bytes,
+};
+use std::sync::Arc;
+
+const MODES: [RecoveryMode; 3] = [
+    RecoveryMode::Strict,
+    RecoveryMode::Lenient,
+    RecoveryMode::Permissive,
+];
+
+const LEVELS: [ValidationLevel; 2] =
+    [ValidationLevel::Structural, ValidationLevel::StrictMarc];
+
+fuzz_target!(|data: &[u8]| {
+    // Share one buffer across the borrowing entry point — the same shape the
+    // Python read path uses (parser and diagnostics context both borrow it).
+    let shared = Arc::new(data.to_vec());
+    for mode in MODES {
+        for level in LEVELS {
+            let _ = parse_record_from_shared_bytes(&shared, mode, level);
+            // The owning entry point moves a fresh buffer in each call.
+            let _ = parse_record_from_bytes(data.to_vec(), mode, level);
+        }
+    }
+});

--- a/src/rayon_parser_pool.rs
+++ b/src/rayon_parser_pool.rs
@@ -68,13 +68,16 @@ pub fn parse_batch_parallel(
 ) -> Result<Vec<Record>> {
     use rayon::prelude::*;
 
-    // Validate all boundaries are within buffer
+    // Validate all boundaries are within buffer. Use checked_add so an
+    // offset near usize::MAX cannot wrap past the bounds check and panic on
+    // the slice below; an overflowing sum is treated as out of bounds.
     for (offset, length) in record_boundaries {
-        if offset + length > buffer.len() {
+        let exceeds = offset
+            .checked_add(*length)
+            .is_none_or(|end| end > buffer.len());
+        if exceeds {
             return Err(MarcError::invalid_field_msg(format!(
-                "Record boundary ({}, {}) exceeds buffer size {}",
-                offset,
-                length,
+                "Record boundary ({offset}, {length}) exceeds buffer size {}",
                 buffer.len()
             )));
         }
@@ -277,6 +280,24 @@ mod tests {
 
         let result = parse_batch_parallel(&boundaries, &buffer);
         assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("exceed") || err_msg.contains("bound"));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_parse_batch_parallel_offset_length_overflow_is_error() {
+        let buffer = vec![1, 2, 3];
+        // An offset near usize::MAX makes offset + length wrap. The guard must
+        // reject it cleanly rather than overflowing (debug) or wrapping past
+        // the check and panicking on the slice (release).
+        let boundaries = vec![(usize::MAX, 1)];
+
+        let result = parse_batch_parallel(&boundaries, &buffer);
+        assert!(
+            result.is_err(),
+            "an overflowing boundary must return an error, not panic"
+        );
         let err_msg = format!("{}", result.unwrap_err());
         assert!(err_msg.contains("exceed") || err_msg.contains("bound"));
     }


### PR DESCRIPTION
Closes #375.

Two robustness follow-ups from the v0.9.0 release-diff review.

### 1. Overflow in the batch-boundary guard

`parse_batch_parallel(boundaries, buffer)` is public on both the Rust side (`mrrc::rayon_parser_pool`) and the Python side (the `_mrrc` extension), and the caller supplies the `(offset, length)` pairs. It bounds-checks each with `offset + length > buffer.len()`. That add is unchecked, so an `offset` near `usize::MAX` makes the sum wrap:

- release build (the shipped wheel): the wrapped sum is small, slips past the `> buffer.len()` check, then panics on the out-of-bounds slice `&buffer[offset..offset + length]`;
- debug build: the add itself panics ("attempt to add with overflow").

From Python that surfaces as a `PanicException` rather than a clean error.

The recommended flow gets boundaries from `RecordBoundaryScanner`, which only ever yields offsets and lengths inside the buffer, so mrrc's readers and normal Python usage never produce a wrapping offset. But the function is public and accepts caller-supplied boundaries, so a caller passing crafted or incorrect `(offset, length)` pairs directly — in Rust or Python — can reach the overflow and gets a panic.

The fix uses `offset.checked_add(length)`, treating an overflowing sum as out of bounds, so the function returns a normal `MarcError` ("boundary exceeds buffer size") for any boundaries instead of panicking. Adds a regression test that passes a `usize::MAX` offset and asserts a clean error.

### 2. Fuzz coverage for the byte-source parse path

`parse_record_from_bytes` / `parse_record_from_shared_bytes` parse one record from an in-memory buffer through `parse_iso2709_record_from_bytes` — its own leader-length guard, truncated-body copy, and `LEADER_LEN..LEADER_LEN + expected_data_len` slice — a distinct code path from the streaming `MarcReader`. `parse_record_from_shared_bytes` is the path the Python reader uses in production, yet all 13 existing fuzz targets drive only the streaming reader, so this path had no fuzz coverage.

Adds `fuzz/fuzz_targets/parse_record_from_bytes.rs` driving both entry points across every recovery mode and validation level, so a malformed-input panic there would be caught. Built and fuzzed locally (255k runs, no crashes).

## Checklist

- [x] `.cargo/check.sh` passes locally
- [x] Tests added or updated for the change
- [x] `CHANGELOG.md` updated under `[Unreleased]` — batch-boundary overflow guard noted under Fixed
- [x] Documentation updated (docstrings, type stubs, `docs/` pages as applicable) — new fuzz target is self-documenting; registered in `fuzz/Cargo.toml`
- [ ] Python API changes follow pymarc conventions and update all four layers — N/A: no Python API change
- [x] Related tracked issue referenced

Bead: bd-9bxa
