### PR TITLE
Batch per-chunk channel sends in the producer-consumer pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `ProducerConsumerPipeline` sends parsed records to its consumer one batch per
+  file chunk instead of one record at a time. Its `channel_capacity` argument now
+  counts batches (each one parsed file chunk) rather than records, and defaults
+  to 4; callers that set it explicitly should adjust.
+
 ### Fixed
 
 - The binary writers now reject a single field whose serialized length exceeds

--- a/src-python/src/producer_consumer_pipeline_wrapper.rs
+++ b/src-python/src/producer_consumer_pipeline_wrapper.rs
@@ -13,7 +13,7 @@ use pyo3::prelude::*;
 /// Design:
 /// - **Producer:** Background thread reading file chunks, scanning boundaries, parsing in parallel
 /// - **Consumer:** Main thread iterating over parsed records
-/// - **Backpressure:** Channel capacity limits buffer to 1000 records
+/// - **Backpressure:** Channel holds a few parsed batches (each batch is one file chunk)
 ///
 /// # Example
 ///
@@ -51,7 +51,8 @@ impl PyProducerConsumerPipeline {
     ///
     /// * `path` - Path to MARC file
     /// * `buffer_size` - Optional: File I/O buffer size (default: 512 KB)
-    /// * `channel_capacity` - Optional: Channel capacity in records (default: 1000)
+    /// * `channel_capacity` - Optional: Channel capacity in parsed batches, each
+    ///   one file chunk (default: 4)
     ///
     /// # Raises
     ///
@@ -68,7 +69,7 @@ impl PyProducerConsumerPipeline {
     /// pipeline = ProducerConsumerPipeline.from_file(
     ///     "records.mrc",
     ///     buffer_size=1024*1024,  # 1 MB
-    ///     channel_capacity=500    # 500 records
+    ///     channel_capacity=8      # up to 8 parsed batches
     /// )
     /// ```
     #[staticmethod]
@@ -80,7 +81,7 @@ impl PyProducerConsumerPipeline {
     ) -> PyResult<Self> {
         let config = PipelineConfig {
             buffer_size: buffer_size.unwrap_or(512 * 1024),
-            channel_capacity: channel_capacity.unwrap_or(1000),
+            channel_capacity: channel_capacity.unwrap_or(4),
             batch_size: 100, // Fixed at 100 per spec
         };
 

--- a/src/producer_consumer_pipeline.rs
+++ b/src/producer_consumer_pipeline.rs
@@ -6,15 +6,17 @@
 //! Design:
 //! - **Producer:** Background task reading file chunks, scanning boundaries, parsing batches
 //! - **Consumer:** Python-facing iterator that drains the bounded channel
-//! - **Backpressure:** Channel capacity = 1000 records; blocks producer when full
+//! - **Backpressure:** Channel holds a small number of parsed batches; blocks the producer when full
 //! - **GIL:** Producer runs without GIL; consumer manages GIL on retrieval
 
 use crate::boundary_scanner::RecordBoundaryScanner;
 use crate::rayon_parser_pool::parse_batch_parallel;
 use crate::record::Record;
 use crossbeam_channel::{Receiver, Sender, bounded};
+use std::collections::VecDeque;
 use std::fs::File;
 use std::io::Read;
+use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::thread;
 
 /// Configuration for the producer-consumer pipeline
@@ -22,7 +24,7 @@ use std::thread;
 pub struct PipelineConfig {
     /// Buffer size for file I/O (bytes)
     pub buffer_size: usize,
-    /// Channel capacity (records)
+    /// Channel capacity in parsed batches (one batch is one parsed file chunk)
     pub channel_capacity: usize,
     /// Batch size for parser pool
     pub batch_size: usize,
@@ -32,7 +34,7 @@ impl Default for PipelineConfig {
     fn default() -> Self {
         Self {
             buffer_size: 512 * 1024, // 512 KB
-            channel_capacity: 1000,  // 1000 records
+            channel_capacity: 4,     // up to 4 parsed batches buffered
             batch_size: 100,         // 100 records per batch
         }
     }
@@ -76,7 +78,7 @@ impl std::error::Error for PipelineError {}
 /// Producer task: reads file, scans boundaries, parses in parallel, sends to channel
 fn producer_task(
     file: File,
-    sender: &Sender<Record>,
+    sender: &Sender<Vec<Record>>,
     config: &PipelineConfig,
 ) -> PipelineResult<()> {
     let mut file = file;
@@ -113,10 +115,12 @@ fn producer_task(
                 let records = parse_batch_parallel(&boundaries, &current_buffer)
                     .map_err(|e| PipelineError::ParseError(e.to_string()))?;
 
-                // Send records to channel (blocks if full = backpressure)
-                for record in records {
+                // Send the whole parsed batch as one channel message (blocks if
+                // full = backpressure). One send per chunk instead of one per
+                // record; the consumer drains a local buffer. Skip empty batches.
+                if !records.is_empty() {
                     sender
-                        .send(record)
+                        .send(records)
                         .map_err(|_| PipelineError::ChannelSendError)?;
                 }
 
@@ -140,7 +144,13 @@ fn producer_task(
 /// Consumer-facing pipeline handle
 #[derive(Debug)]
 pub struct ProducerConsumerPipeline {
-    receiver: Receiver<Record>,
+    receiver: Receiver<Vec<Record>>,
+    /// Records drained from the most recent batch but not yet handed out. The
+    /// channel delivers a `Vec<Record>` per chunk; the consumer hands records
+    /// out one at a time from here. A `Mutex` provides the interior mutability
+    /// the `&self` accessors need; the consumer is single-threaded, so the lock
+    /// is uncontended and is never held across the blocking channel `recv`.
+    buffer: Mutex<VecDeque<Record>>,
     /// Optional handle to producer thread for join semantics
     _producer_handle: Option<thread::JoinHandle<PipelineResult<()>>>,
 }
@@ -164,15 +174,22 @@ impl ProducerConsumerPipeline {
 
         Ok(ProducerConsumerPipeline {
             receiver,
+            buffer: Mutex::new(VecDeque::new()),
             _producer_handle: Some(producer_handle),
         })
+    }
+
+    /// Lock the local record buffer, recovering from a poisoned lock (a
+    /// poisoned buffer still holds valid records — no need to abort).
+    fn lock_buffer(&self) -> MutexGuard<'_, VecDeque<Record>> {
+        self.buffer.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
     /// Try to get next record without blocking
     ///
     /// Returns:
-    /// - Ok(Some(record)) if record available
-    /// - Ok(None) if channel empty or closed
+    /// - Ok(Some(record)) if a record is buffered or a batch is waiting
+    /// - Ok(None) if nothing is currently available (channel empty or closed)
     /// - Err if producer panicked
     ///
     /// # Errors
@@ -181,26 +198,39 @@ impl ProducerConsumerPipeline {
     pub fn try_next(&self) -> PipelineResult<Option<Record>> {
         use crossbeam_channel::TryRecvError;
 
-        match self.receiver.try_recv() {
-            Ok(record) => Ok(Some(record)),
-            Err(TryRecvError::Empty | TryRecvError::Disconnected) => Ok(None),
+        loop {
+            if let Some(record) = self.lock_buffer().pop_front() {
+                return Ok(Some(record));
+            }
+            // Buffer empty: pull the next batch without blocking and refill.
+            match self.receiver.try_recv() {
+                Ok(batch) => self.lock_buffer().extend(batch),
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => return Ok(None),
+            }
         }
     }
 
     /// Get next record, blocking if necessary
     ///
     /// Returns:
-    /// - Ok(Some(record)) if record available
-    /// - Ok(None) if EOF (channel closed and empty)
+    /// - Ok(Some(record)) if a record is available (buffered or from a batch)
+    /// - Ok(None) if EOF (channel closed and the buffer is drained)
     /// - Err if producer panicked
     ///
     /// # Errors
     ///
     /// Currently returns Ok(None) on channel disconnection.
     pub fn next(&self) -> PipelineResult<Option<Record>> {
-        match self.receiver.recv() {
-            Ok(record) => Ok(Some(record)),
-            Err(_) => Ok(None), // Channel closed = EOF
+        loop {
+            if let Some(record) = self.lock_buffer().pop_front() {
+                return Ok(Some(record));
+            }
+            // Buffer empty: block for the next batch, then refill. The lock is
+            // not held across recv, so a blocked consumer never holds it.
+            match self.receiver.recv() {
+                Ok(batch) => self.lock_buffer().extend(batch),
+                Err(_) => return Ok(None), // Channel closed and drained = EOF
+            }
         }
     }
 
@@ -209,7 +239,16 @@ impl ProducerConsumerPipeline {
     /// Yields records until EOF. Blocks if producer is slow.
     #[allow(clippy::should_implement_trait)]
     pub fn into_iter(self) -> impl Iterator<Item = PipelineResult<Record>> {
-        self.receiver.into_iter().map(Ok)
+        // Hand out any records already buffered by next()/try_next(), then
+        // flatten the remaining batches off the channel.
+        let buffered = self
+            .buffer
+            .into_inner()
+            .unwrap_or_else(PoisonError::into_inner);
+        buffered
+            .into_iter()
+            .chain(self.receiver.into_iter().flatten())
+            .map(Ok)
     }
 }
 
@@ -221,7 +260,7 @@ mod tests {
     fn test_pipeline_config_default() {
         let config = PipelineConfig::default();
         assert_eq!(config.buffer_size, 512 * 1024);
-        assert_eq!(config.channel_capacity, 1000);
+        assert_eq!(config.channel_capacity, 4);
         assert_eq!(config.batch_size, 100);
     }
 
@@ -245,5 +284,124 @@ mod tests {
         let config = PipelineConfig::default();
         let result = ProducerConsumerPipeline::from_file("/nonexistent/path", &config);
         assert!(result.is_err());
+    }
+
+    /// Build a valid bibliographic record with the given 001 control number.
+    fn build_record(control_number: &str) -> Record {
+        use crate::leader::Leader;
+        use crate::record::Field;
+        let leader = Leader {
+            record_length: 0,
+            record_status: 'n',
+            record_type: 'a',
+            bibliographic_level: 'm',
+            control_record_type: ' ',
+            character_coding: 'a',
+            indicator_count: 2,
+            subfield_code_count: 2,
+            data_base_address: 0,
+            encoding_level: ' ',
+            cataloging_form: ' ',
+            multipart_level: ' ',
+            reserved: "4500".to_string(),
+        };
+        let mut record = Record::new(leader);
+        record.add_control_field("001".to_string(), control_number.to_string());
+        let field = Field::builder("245".to_string(), '1', '0')
+            .subfield_str('a', "Title")
+            .build();
+        record.add_field(field);
+        record
+    }
+
+    /// The pipeline must deliver every record exactly once, in input order,
+    /// across many file chunks. A small buffer and channel capacity force the
+    /// records to span many chunks (and exercise backpressure), so the test
+    /// guards the producer's batching and the consumer's drain regardless of
+    /// how records are grouped onto the channel.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_pipeline_preserves_order_and_count_across_chunks() {
+        use crate::writer::MarcWriter;
+        use std::io::Write;
+
+        let n = 50;
+        let mut bytes = Vec::new();
+        for i in 0..n {
+            let record = build_record(&format!("rec{i:04}"));
+            let mut buf = Vec::new();
+            MarcWriter::new(&mut buf)
+                .write_record(&record)
+                .expect("write should succeed");
+            bytes.extend_from_slice(&buf);
+        }
+
+        let mut tmp = tempfile::NamedTempFile::new().expect("temp file");
+        tmp.write_all(&bytes).expect("write temp");
+
+        // Small buffer + small capacity force many chunks and backpressure.
+        let config = PipelineConfig {
+            buffer_size: 256,
+            channel_capacity: 4,
+            batch_size: 100,
+        };
+        let pipeline =
+            ProducerConsumerPipeline::from_file(tmp.path().to_str().expect("utf8 path"), &config)
+                .expect("pipeline opens");
+
+        let got: Vec<Record> = pipeline.into_iter().map(|r| r.expect("record")).collect();
+
+        assert_eq!(got.len(), n, "all records delivered");
+        for (i, rec) in got.iter().enumerate() {
+            assert_eq!(
+                rec.get_control_field("001"),
+                Some(format!("rec{i:04}").as_str()),
+                "record {i} out of order or corrupted"
+            );
+        }
+    }
+
+    /// `next()` and `try_next()` must hand out records one at a time in order
+    /// even though the channel now delivers whole batches — the local buffer
+    /// has to be drained before the next batch is pulled.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_pipeline_next_drains_batches_in_order() {
+        use crate::writer::MarcWriter;
+        use std::io::Write;
+
+        let n = 30;
+        let mut bytes = Vec::new();
+        for i in 0..n {
+            let record = build_record(&format!("rec{i:04}"));
+            let mut buf = Vec::new();
+            MarcWriter::new(&mut buf)
+                .write_record(&record)
+                .expect("write should succeed");
+            bytes.extend_from_slice(&buf);
+        }
+
+        let mut tmp = tempfile::NamedTempFile::new().expect("temp file");
+        tmp.write_all(&bytes).expect("write temp");
+
+        let config = PipelineConfig {
+            buffer_size: 512,
+            channel_capacity: 2,
+            batch_size: 100,
+        };
+        let pipeline =
+            ProducerConsumerPipeline::from_file(tmp.path().to_str().expect("utf8 path"), &config)
+                .expect("pipeline opens");
+
+        let mut seen = 0;
+        while let Some(record) = pipeline.next().expect("next should succeed") {
+            assert_eq!(
+                record.get_control_field("001"),
+                Some(format!("rec{seen:04}").as_str()),
+                "record {seen} out of order"
+            );
+            seen += 1;
+        }
+        assert_eq!(seen, n, "next() delivered every record");
     }
 }


### PR DESCRIPTION
Closes #374.

Secondary perf follow-up from the v0.8.2 review (PERF-8). The producer-consumer pipeline sent one crossbeam-channel message per record; it now sends the whole parsed batch (one per file chunk) as a single `Vec<Record>`, and the consumer hands records out one at a time from a local `VecDeque`, refilling from the channel when it empties. Channel operations drop from one-per-record to one-per-chunk.

- **Producer:** `Sender<Vec<Record>>`; sends the chunk's parsed `records` in one `send` (skips empty batches).
- **Consumer:** a local `VecDeque<Record>` drained by `next()`/`try_next()`; `into_iter()` flattens batches. The core `next()`/`try_next()` stay `&self` (no public-API break) — a `Mutex` provides the buffer's interior mutability. The single consumer never contends the lock, and the lock is never held across the blocking `recv`.
- **`channel_capacity`:** now counts batches (each one parsed file chunk) rather than records; default 4. This changes the meaning and default of the Python `ProducerConsumerPipeline(..., channel_capacity=...)` argument for callers that set it explicitly — noted in the CHANGELOG. The argument's type is unchanged, so the stub signature is unaffected.

Tests: adds Rust tests that every record arrives exactly once in input order across many small chunks, and that `next()` drains each batch in order before pulling the next. The existing Python 10k-record regression (records spanning chunk boundaries) passes against the batched pipeline.

## Checklist

- [x] `.cargo/check.sh` passes locally
- [x] Tests added or updated for the change
- [x] `CHANGELOG.md` updated under `[Unreleased]` — `channel_capacity` semantics/default change, under Changed
- [x] Documentation updated (docstrings, type stubs, `docs/` pages as applicable) — pipeline rustdoc and the PyO3 `channel_capacity` docs; stub signature unchanged
- [x] Python API changes follow pymarc conventions and update all four layers — `ProducerConsumerPipeline` is an mrrc-specific advanced API with no pymarc analogue; the behavior change is documented and the stub signature is unchanged
- [x] Related tracked issue referenced

Bead: bd-yfxy
