### PR TITLE
Update guides and reference docs for the v0.9.1 pipeline and fuzz changes

### DIFF
--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -254,7 +254,7 @@ for record in pipeline:
 
 **How it works:**
 - Background producer thread reads file in 512 KB chunks
-- Bounded channel provides backpressure (1000 records)
+- Bounded channel provides backpressure (a few parsed batches, one per file chunk)
 - Rayon parses batches in parallel on all CPU cores
 - Producer runs without GIL, eliminating contention
 

--- a/docs/contributing/fuzzing.md
+++ b/docs/contributing/fuzzing.md
@@ -14,6 +14,8 @@ playbook for investigating CI findings.
 |--------|-------------|--------|
 | `parse_record` | `MarcReader::read_record` over the full ISO 2709 reader | Active |
 | `roundtrip_binary` | Parse → serialize → parse-again coupling | Active |
+| `parse_record_from_bytes` | In-memory byte-source entry points (`parse_record_from_bytes` / `parse_record_from_shared_bytes`) | Active |
+| `write_arbitrary_records` | The three ISO 2709 writers over arbitrary records | Active |
 | `error_classification` | Strict-mode reader with per-input behavioral assertions | Active |
 | `recovery_mode_consistency` | Cross-mode behavioral consistency across strict / lenient / permissive | Active |
 | `decode_marc8` | MARC-8 encoding state machine | Active |
@@ -96,6 +98,21 @@ default strict mode (stopping at the first malformed record) and
 this is the only target exercising the salvage path across a stream:
 per-record error accumulation, skip-ahead to the next record boundary,
 and the error-cap bookkeeping.
+
+`parse_record_from_bytes` drives the in-memory byte-source entry points —
+`parse_record_from_bytes` and `parse_record_from_shared_bytes` — across every
+recovery mode and validation level. These run the divergent
+`parse_iso2709_record_from_bytes` path (its own leader-length guard,
+truncated-body copy, and data-area slice) that the reader-driven targets never
+reach; `parse_record_from_shared_bytes` is the production Python read path.
+
+`write_arbitrary_records` is the write-side analogue: it builds arbitrary
+`Record` / `AuthorityRecord` / `HoldingsRecord` values and runs each through its
+ISO 2709 writer, asserting the output is either a clean `WriterError` or parses
+back through the matching reader. Reader-gated targets like `roundtrip_binary`
+only ever see records the reader produced, so they never reach writer behavior
+that manifests only on API-constructed records (the class of bug behind the
+9999-byte directory-entry fix).
 
 ## Installing cargo-fuzz
 

--- a/docs/guides/working-with-large-files.md
+++ b/docs/guides/working-with-large-files.md
@@ -109,7 +109,7 @@ from mrrc import ProducerConsumerPipeline
 pipeline = ProducerConsumerPipeline.from_file(
     'large_file.mrc',
     buffer_size=1024*1024,    # File I/O buffer size (default: 512 KB)
-    channel_capacity=500       # Channel capacity in records (default: 1000)
+    channel_capacity=8         # Parsed batches buffered, one per chunk (default: 4)
 )
 ```
 
@@ -124,14 +124,17 @@ difference on your own files with the timing pattern in the
 ### Memory Considerations
 
 ```python
-# Memory usage = channel_capacity * avg_record_size + buffer_size
-# For 1000 records @ 2KB each + 512KB buffer = ~2.5MB
+# Each channel slot holds one parsed batch — the records from a single
+# buffer_size file chunk — so buffered memory grows with
+# channel_capacity * (records per chunk) + buffer_size. The defaults
+# (channel_capacity=4, buffer_size=512 KB) keep a few chunks in flight.
 
-# Reduce memory for constrained environments
+# Reduce memory for constrained environments: smaller chunks (smaller
+# batches) and fewer batches buffered.
 pipeline = ProducerConsumerPipeline.from_file(
     'large_file.mrc',
-    buffer_size=64*1024,     # 64KB I/O buffer
-    channel_capacity=100      # Smaller channel
+    buffer_size=64*1024,     # 64KB I/O buffer -> smaller chunks -> smaller batches
+    channel_capacity=2       # fewer batches buffered
 )
 ```
 

--- a/docs/reference/rust-api.md
+++ b/docs/reference/rust-api.md
@@ -179,6 +179,30 @@ writer.write_record(&record)?;
 | `new(writer)` | `MarcWriter<W>` | Create from any `Write` |
 | `write_record(record)` | `Result<()>` | Write a record |
 
+### Parsing a single record from bytes
+
+When you already hold one record's bytes in memory, parse it directly without
+constructing a reader:
+
+```rust
+use mrrc::{parse_record_from_bytes, RecoveryMode, ValidationLevel};
+
+let bytes: Vec<u8> = std::fs::read("one_record.mrc")?;
+let record = parse_record_from_bytes(
+    bytes,
+    RecoveryMode::Strict,
+    ValidationLevel::Structural,
+)?;
+```
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `parse_record_from_bytes(bytes, recovery, validation)` | `Result<Option<Record>>` | Parse one record from an owned `Vec<u8>` |
+| `parse_record_from_shared_bytes(&Arc<Vec<u8>>, recovery, validation)` | `Result<Option<Record>>` | Same, but borrows a shared buffer instead of taking ownership |
+
+Unlike the streaming reader, a non-empty buffer shorter than the 24-byte leader
+is a `TruncatedRecord` error here rather than end-of-stream.
+
 ## Specialized Record Types
 
 ### AuthorityRecord


### PR DESCRIPTION
Pre-release docs pass: brings the guides and reference up to date with v0.9.1 changes that left stale text behind.

- **`docs/guides/working-with-large-files.md`** (user-facing) — `ProducerConsumerPipeline`'s `channel_capacity` changed from a record count (default 1000) to a batch count (default 4) in #381. Fixed the configuration example, and rewrote the memory model: each channel slot now holds one parsed batch (the records from a single `buffer_size` chunk), so the old `channel_capacity * avg_record_size` formula and the "smaller channel = 100" advice were wrong/backwards.
- **`docs/contributing/architecture.md`** — pipeline backpressure described as "a few parsed batches" rather than "1000 records".
- **`docs/contributing/fuzzing.md`** — added the two new fuzz targets to the "What is tested" inventory and prose: `parse_record_from_bytes` (#377) and `write_arbitrary_records` (#384).
- **`docs/reference/rust-api.md`** — documented the `parse_record_from_bytes` / `parse_record_from_shared_bytes` byte-source entry points (the curated page previously deferred entirely to docs.rs for these).

Docs-only; no code or beads. `mkdocs build --strict` is clean.

## Checklist

- [x] `.cargo/check.sh` passes locally
- [ ] Tests added or updated for the change — N/A: docs only
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — N/A: the underlying changes are already in the changelog; this only corrects docs prose
- [x] Documentation updated (docstrings, type stubs, `docs/` pages as applicable)
- [ ] Python API changes follow pymarc conventions and update all four layers — N/A: no API change
- [x] Related tracked issue referenced — none (small docs follow-up)
