### PR TITLE
Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Performance
+
+### Documentation
+
+## [0.9.1] - 2026-06-28
+
+### Added
+
 - New cargo-fuzz targets covering the in-memory byte-source parse entry points
   (`parse_record_from_bytes` / `parse_record_from_shared_bytes`) and the three
   ISO 2709 writers (`write_arbitrary_records`, over arbitrary records), run
@@ -50,8 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   buffer up front: the reader borrows the immutable `bytes` and slices records
   out of it, avoiding a full-dataset copy at construction for large in-memory
   inputs. `bytearray` input is unchanged (still snapshotted to an owned buffer).
-
-### Documentation
 
 ## [0.9.0] - 2026-06-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "mrrc"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "codspeed-criterion-compat",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "mrrc-python"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "mrrc",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 # `dynamic = ["version"]` and maturin reads src-python/Cargo.toml,
 # which inherits this version.
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Daniel Chudnov"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Rust library for reading, writing, and manipulating MARC bibliographic records
 - Python bindings with pymarc-compatible API (minor differences documented)
 - Multiple serialization formats: JSON, MARCXML, MARCJSON, CSV, Dublin Core, MODS, BIBFRAME
 - MARC-8 and UTF-8 character encoding support
-- Rust-core parsing with GIL release for multi-threaded Python workloads — roughly 8× pymarc on per-record reads in a recent single-host comparison; see [benchmarks](docs/benchmarks/) for the current three-way figures
+- Rust-core parsing with GIL release for multi-threaded Python workloads — roughly 8× pymarc on per-record reads in a recent single-host comparison; see [benchmarks](https://dchud.github.io/mrrc/benchmarks/) for the current three-way figures
 
 ## Installation
 
@@ -105,7 +105,7 @@ Pre-built Python wheels are available for:
 
 ## Roadmap
 
-Version 0.9.0 is suitable for testing but remains experimental. Before a 1.0 release, we plan to complete:
+Version 0.9.1 is suitable for testing but remains experimental. Before a 1.0 release, we plan to complete:
 
 1. **Real-world data testing** — Validate against large-scale MARC datasets from LOC, Internet Archive, and other sources to discover edge cases
 2. **Code review** — Thorough review of the codebase, particularly the Rust core and `PyO3` bindings


### PR DESCRIPTION
Workspace version bump to **0.9.1** and CHANGELOG finalization. Merging this, then tagging the merged commit (`v0.9.1`), triggers publication via the release workflow.

Changes:
- `[workspace.package]` version → 0.9.1 (both crates and the Python package inherit it); `Cargo.lock` refreshed.
- `CHANGELOG.md`: `[Unreleased]` finalized as `[0.9.1] - 2026-06-28`; a fresh empty `[Unreleased]` added above it.
- `README.md`: benchmarks link now points to the published docs site (`https://dchud.github.io/mrrc/benchmarks/`) instead of a repo-relative path; roadmap version line bumped to 0.9.1.

The 0.9.1 changes themselves (robustness fixes, fuzz coverage, the pipeline batching, perf work) are already on `main` from the milestone's PRs; this PR only stamps the version and release notes.

## Checklist

- [x] `.cargo/check.sh` passes locally
- [ ] Tests added or updated for the change — N/A: release stamp (version + changelog + docs link)
- [x] `CHANGELOG.md` updated under `[Unreleased]` — finalized to `[0.9.1]`
- [x] Documentation updated (docstrings, type stubs, `docs/` pages as applicable) — README benchmarks link + roadmap version
- [ ] Python API changes follow pymarc conventions and update all four layers — N/A
- [x] Related tracked issue referenced — v0.9.1 milestone

**Do not tag until this merges.** The maintainer creates and pushes `v0.9.1` on the merged commit (procedure §7.3), which triggers PyPI/GitHub Release publication.
