### PR TITLE
docs(changelog): record merged Dependabot version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+### Dependencies
+
+- Bump pytest from 9.1.0 to 9.1.1
+- Bump ruff from 0.15.17 to 0.15.18
+- Bump pymdown-extensions from 10.21.3 to 11.0
+- Bump foldhash from 0.1.5 to 0.2.0
+- Bump CodSpeedHQ/action from 4.17.5 to 4.17.6
+- Bump softprops/action-gh-release from 3.0.0 to 3.0.1
+- Bump actions/checkout from 6.0.3 to 7.0.0
+- Bump actions/cache from 5 to 6.1.0
+
 ## [0.9.1] - 2026-06-28
 
 ### Added


### PR DESCRIPTION
Records the Dependabot dependency bumps that merged to `main` since v0.9.1 in the changelog's `[Unreleased]` section, so they are captured for the next release notes.

Eight bumps under a new `### Dependencies` block, matching the format and position of every prior release's Dependencies section:

- pytest 9.1.0 → 9.1.1
- ruff 0.15.17 → 0.15.18
- pymdown-extensions 10.21.3 → 11.0
- foldhash 0.1.5 → 0.2.0
- CodSpeedHQ/action 4.17.5 → 4.17.6
- softprops/action-gh-release 3.0.0 → 3.0.1
- actions/checkout 6.0.3 → 7.0.0
- actions/cache 5 → 6.1.0

`foldhash` (PR #390) merged a `Cargo.lock` edge (`0.2.0`) that sat outside the manifest's `foldhash = "0.1.5"` requirement, so the bump did not actually take effect. PR #399 bumps the manifest to `0.2.0` to make it effective; this line records that bump. The other seven were already effective on merge.

## Checklist

- [x] Changelog lint passes (`bash scripts/lint-changelog.sh`); full `.cargo/check.sh` not applicable to a changelog-only change
- [ ] ~~Tests added or updated~~ — N/A (changelog only)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] ~~Documentation updated~~ — N/A
- [ ] ~~Python API changes follow pymarc conventions~~ — N/A
- [ ] ~~Related tracked issue referenced~~ — N/A (routine changelog upkeep, no bead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
