### PR TITLE
chore(deps): adopt foldhash 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ indexmap = { version = "2.2", features = ["serde"] }
 
 # Fast non-cryptographic hasher for the tag-keyed record maps (see
 # `TagIndexMap` in src/record.rs).
-foldhash = "0.1.5"
+foldhash = "0.2.0"
 
 # Error handling
 thiserror = "2.0"


### PR DESCRIPTION
Sets the `foldhash` requirement in `Cargo.toml` to `0.2.0`, matching the lockfile edge that Dependabot PR #390 already moved mrrc to.

PR #390 ("Bump foldhash from 0.1.5 to 0.2.0") updated only `Cargo.lock`, not `Cargo.toml`. That left mrrc's manifest requiring `foldhash = "0.1.5"` (`<0.2.0`) while the lockfile pinned mrrc's own edge at `0.2.0` — so `cargo build --locked` failed on `main`, and any non-locked build silently re-resolved back to `0.1.5`. This one-line manifest bump makes the two consistent; `Cargo.lock` needs no change (it already carries `0.2.0`).

foldhash 0.2.0 is a routine performance release, not a security fix (no GHSA/CVE; `cargo audit` is clean for foldhash in both versions). Its only breaking change — `Copy` removed from the hasher states — does not affect mrrc, which names `foldhash::fast::FixedState` solely as a type parameter for `TagIndexMap`. Verified: `cargo check --locked --workspace` passes and all 582 lib tests pass with no source changes.

The changelog line for this bump (`- Bump foldhash from 0.1.5 to 0.2.0`) is recorded alongside the other merged Dependabot bumps in #397.

## Checklist

- [x] `.cargo/check.sh` passes locally (pre-commit hook); additionally verified `cargo check --locked --workspace`
- [ ] ~~Tests added or updated~~ — N/A (dependency version bump; the existing suite exercises the hasher)
- [ ] ~~`CHANGELOG.md` updated~~ — recorded in #397 (the dependency-bumps changelog PR)
- [ ] ~~Documentation updated~~ — N/A
- [ ] ~~Python API changes follow pymarc conventions~~ — N/A
- [ ] ~~Related tracked issue referenced~~ — N/A (follow-up to Dependabot PR #390; no bead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
