### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Bump quick-xml to 0.41.0, fixing the RUSTSEC-2026-0194/0195 DoS advisories on the MARCXML path.
+- Bump crossbeam-epoch to 0.9.20, fixing the RUSTSEC-2026-0204 invalid-pointer-dereference
+  advisory (reached transitively through rayon).
 
 ### Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Bumps `crossbeam-epoch` 0.9.18 → 0.9.20 to clear **RUSTSEC-2026-0204** (published 2026-07-06): an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid, fixed in `>= 0.9.20`.

`crossbeam-epoch` reaches mrrc transitively through rayon (`crossbeam-epoch → crossbeam-deque → rayon-core → rayon → mrrc`), so it sits on the parallel-parse path, not only dev/bench dependencies. This is a lockfile bump with a matching CHANGELOG Security note; `cargo audit` returns to zero vulnerabilities and the full `.cargo/check.sh` passes.

Timing note: `main`'s audit is green as of today's 08:53 UTC scheduled run only because the advisory was published afterward — the next scheduled run (2026-07-07 05:00 UTC) would fail without this. No source or API changes.

## Checklist

- [x] `.cargo/check.sh` passes locally
- [ ] ~~Tests added or updated~~ — N/A (transitive lockfile bump, no code change)
- [x] `CHANGELOG.md` updated under `[Unreleased] → Security`
- [ ] ~~Documentation updated~~ — N/A
- [ ] ~~Python API changes follow pymarc conventions~~ — N/A (no API change)
- [ ] ~~Related tracked issue referenced~~ — N/A (no bead; the version bump fully resolves the advisory, nothing to track for later removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)