### PR TITLE
docs(changelog): record merged dependency bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump quick-xml to 0.41.0, fixing the RUSTSEC-2026-0194/0195 DoS advisories on the MARCXML path.
 - Bump crossbeam-epoch to 0.9.20, fixing the RUSTSEC-2026-0204 invalid-pointer-dereference
   advisory (reached transitively through rayon).
+- Bump anyhow to 1.0.103, resolving the RUSTSEC-2026-0190 unsoundness advisory in
+  `Error::downcast_mut()`.
 
 ### Dependencies
 
 - Bump pytest from 9.1.0 to 9.1.1
-- Bump ruff from 0.15.17 to 0.15.18
+- Bump ruff from 0.15.17 to 0.15.20
 - Bump pymdown-extensions from 10.21.3 to 11.0
 - Bump foldhash from 0.1.5 to 0.2.0
-- Bump CodSpeedHQ/action from 4.17.5 to 4.17.6
+- Bump CodSpeedHQ/action from 4.17.5 to 4.18.1
 - Bump softprops/action-gh-release from 3.0.0 to 3.0.1
 - Bump actions/checkout from 6.0.3 to 7.0.0
 - Bump actions/cache from 5 to 6.1.0
+- Bump pyright from 1.1.410 to 1.1.411
+- Bump syrupy from 5.3.2 to 5.3.4
 
 ## [0.9.1] - 2026-06-28
 


### PR DESCRIPTION
Records the five dependency bumps merged since the last CHANGELOG update (#403–#407) in the `[Unreleased]` section:

- anyhow 1.0.103 goes under **Security** — it closes RUSTSEC-2026-0190 (`Error::downcast_mut()` unsoundness), which the nightly `cargo audit` job flagged in #408 alongside the crossbeam-epoch advisory already fixed by #402.
- ruff (→0.15.20) and CodSpeedHQ/action (→4.18.1) are folded into their existing `[Unreleased]` ranges rather than adding duplicate lines.
- pyright (→1.1.411) and syrupy (→5.3.4) are added under **Dependencies**.

`cargo audit` now passes clean on `main`, so #408 is resolved — no code fix required. Closing it separately.

## Checklist

- [x] `.cargo/check.sh` passes locally
- [ ] Tests added or updated for the change — N/A (CHANGELOG-only)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (user-facing changes only)
- [ ] Documentation updated — N/A
- [ ] Python API changes follow pymarc conventions and update all four layers — N/A
- [ ] Related tracked issue referenced — N/A (no bead; documents merged Dependabot PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)