### PR TITLE
Release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+## [0.9.2] - 2026-07-27
+
 ### Security
 
 - Bump quick-xml to 0.41.0, fixing the RUSTSEC-2026-0194/0195 DoS advisories on the MARCXML

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "mrrc"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "codspeed-criterion-compat",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "mrrc-python"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "mrrc",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 # `dynamic = ["version"]` and maturin reads src-python/Cargo.toml,
 # which inherits this version.
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Daniel Chudnov"]

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Pre-built Python wheels are available for:
 
 ## Roadmap
 
-Version 0.9.1 is suitable for testing but remains experimental. Before a 1.0 release, we plan to complete:
+Version 0.9.2 is suitable for testing but remains experimental. Before a 1.0 release, we plan to complete:
 
 1. **Real-world data testing** — Validate against large-scale MARC datasets from LOC, Internet Archive, and other sources to discover edge cases
 2. **Code review** — Thorough review of the codebase, particularly the Rust core and `PyO3` bindings


### PR DESCRIPTION
Workspace version bump to 0.9.2 and CHANGELOG finalization. Merging this, then tagging the merged commit, triggers publication.

## What this release is

A patch release carrying dependency and security bumps only. `Added`, `Changed`, `Fixed`, and `Performance` are empty — there is no functional change.

Two reasons it is worth cutting:

**crates.io consumers are structurally blocked without it.** v0.9.1 pinned `quick-xml = "0.40"`, which under Cargo's 0.x caret semantics resolves to `>=0.40.0, <0.41.0`. No amount of `cargo update` reaches the fixed 0.41. Only a release carrying the raised bound unblocks them. PyPI wheel users are in a similar position for a different reason: the wheel is a compiled binary with quick-xml 0.40.1 and crossbeam-epoch 0.9.18 baked in, so they cannot fix either advisory themselves.

**It exercises release plumbing that has never been run.** The required-reviewer PyPI environment (#411) and the SHA-pinned, hardened release workflows (#412) both landed after v0.9.1. A release with no functional content is a low-risk way to find out whether that machinery works, rather than discovering a problem during a release that matters.

## Scope note

This release does **not** clear `cargo audit`. RUSTSEC-2026-0194/0195 still fire through `oxrdfxml → quick-xml 0.37.5`, and `bibframe` is a default feature the wheel always enables. The CHANGELOG entry states this explicitly so the release notes are not read as an all-clear. Upstream merged the fix on 2026-07-10 but has not released it, and it is arriving as `oxrdfio` 0.3 / `oxrdf` 0.4 — a two-major-version migration tracked in bd-7u63.

## Verification

- All 41 commits since v0.9.1 audited against `[Unreleased]`; the non-dependency ones are changelog bookkeeping, beads/design-doc internals, and a markdown reformat of one guide — none user-facing.
- `.cargo/check.sh` passes.
- `cargo metadata` reports both `mrrc` and `mrrc-python` at 0.9.2; `Cargo.lock` refreshed.
- `cargo build --examples` succeeds across all 15 examples.
- `scripts/lint-changelog.sh` exits 0.
- Docs swept for stale version references; `mrrc = "0.9"` pins track the minor line and are unchanged.

## Checklist

- [x] `.cargo/check.sh` passes locally
- [ ] Tests added or updated for the change — N/A, version and changelog only
- [x] `CHANGELOG.md` updated — `[Unreleased]` promoted to `[0.9.2]`, fresh `[Unreleased]` created
- [x] Documentation updated — README roadmap line names 0.9.2
- [ ] Python API changes follow pymarc conventions — N/A, no API change
- [ ] Related tracked issue referenced — N/A, no bead for the release itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)